### PR TITLE
Clip SnapDialog Carousel mouse over correctly when scrolled off screen

### DIFF
--- a/lib/store_app/common/snap_content.dart
+++ b/lib/store_app/common/snap_content.dart
@@ -38,6 +38,7 @@ class SnapContent extends StatelessWidget {
               children: [
                 for (final url in media)
                   InkWell(
+                    hoverColor: Colors.transparent,
                     borderRadius: BorderRadius.circular(10),
                     onTap: () => showDialog(
                       context: context,

--- a/lib/store_app/common/snap_content.dart
+++ b/lib/store_app/common/snap_content.dart
@@ -37,28 +37,31 @@ class SnapContent extends StatelessWidget {
               height: 250,
               children: [
                 for (final url in media)
-                  InkWell(
-                    hoverColor: Colors.transparent,
-                    borderRadius: BorderRadius.circular(10),
-                    onTap: () => showDialog(
-                      context: context,
-                      builder: (context) => SimpleDialog(
-                        children: [
-                          InkWell(
-                            onTap: () => Navigator.of(context).pop(),
-                            child: YaruSafeImage(
-                              url: url,
-                              fit: BoxFit.contain,
-                              filterQuality: FilterQuality.medium,
-                              fallBackIconData: YaruIcons.image,
-                            ),
-                          )
-                        ],
+                  Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(10),
+                      excludeFromSemantics: true,
+                      onTap: () => showDialog(
+                        context: context,
+                        builder: (context) => SimpleDialog(
+                          children: [
+                            InkWell(
+                              onTap: () => Navigator.of(context).pop(),
+                              child: YaruSafeImage(
+                                url: url,
+                                fit: BoxFit.contain,
+                                filterQuality: FilterQuality.medium,
+                                fallBackIconData: YaruIcons.image,
+                              ),
+                            )
+                          ],
+                        ),
                       ),
-                    ),
-                    child: YaruSafeImage(
-                      url: url,
-                      fallBackIconData: YaruIcons.image,
+                      child: YaruSafeImage(
+                        url: url,
+                        fallBackIconData: YaruIcons.image,
+                      ),
                     ),
                   )
               ],


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/15329494/187356236-c4ba131c-1e0d-441f-a50f-781871744ea4.png)

The hover should only be displayed by the mousecursor as with the buttons on the left and right, thus removing the hover color fixes the issue

Fixes #121