### PR TITLE
SnapModel: localize install date tooltip

### DIFF
--- a/lib/store_app/common/snap_dialog.dart
+++ b/lib/store_app/common/snap_dialog.dart
@@ -67,6 +67,7 @@ class _SnapDialogState extends State<SnapDialog> {
               connectionsExpanded: model.connectionsExpanded,
               iconUrl: model.iconUrl ?? '',
               installDate: model.installDate,
+              installDateIsoNorm: model.installDateIsoNorm,
               license: model.license ?? '',
               onConnectionsExpanded: () =>
                   model.connectionsExpanded = !model.connectionsExpanded,

--- a/lib/store_app/common/snap_model.dart
+++ b/lib/store_app/common/snap_model.dart
@@ -79,6 +79,12 @@ class SnapModel extends SafeChangeNotifier {
         .format(_localSnap!.installDate!);
   }
 
+  String get installDateIsoNorm {
+    if (_localSnap == null || _localSnap!.installDate == null) return '';
+
+    return DateFormat('yyyy-MM-dd HH:mm:ss').format(_localSnap!.installDate!);
+  }
+
   /// Installed size in bytes.
   int? get installedSize => _localSnap?.installedSize;
 

--- a/lib/store_app/common/snap_page_header.dart
+++ b/lib/store_app/common/snap_page_header.dart
@@ -17,6 +17,7 @@ class SnapPageHeader extends StatelessWidget {
   final String version;
   final String license;
   final String installDate;
+  final String installDateIsoNorm;
 
   final Function() open;
   final Function() onConnectionsExpanded;
@@ -34,6 +35,7 @@ class SnapPageHeader extends StatelessWidget {
     required this.confinementName,
     required this.license,
     required this.installDate,
+    required this.installDateIsoNorm,
     required this.connectionsNotEmpty,
     required this.onConnectionsExpanded,
   });
@@ -201,7 +203,7 @@ class SnapPageHeader extends StatelessWidget {
               children: [
                 Text(context.l10n.installDate, style: headerStyle),
                 Tooltip(
-                  message: installDate,
+                  message: installDateIsoNorm,
                   child: Text(
                     installDate.isNotEmpty
                         ? installDate


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/15329494/187667371-2eeed876-872f-4034-9861-fd945a36c9a9.png)

@oSoMoN @Jupi007 I didn't find how to get a iso norm but localized so I switched back to your iso norm preference, however, this time without making the view any more "intelligent". I would really like to keep the view as stupid as possible (like in the rest of the views).

Fixes #129