### PR TITLE
Snap: upgrade Flutter to 3.3.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@ assumes:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.0.5 # pinned because of https://github.com/jpnurmi/flutter_raster_cache_bug
+    source-tag: 3.3.2
     plugin: nil
     override-build: |
       set -eux


### PR DESCRIPTION
```
The current Flutter SDK version is 3.0.5.

Because software depends on yaru >=0.4.0 which requires Flutter SDK version >=3.3.0, version solving failed.
Running "flutter pub get" in software...                                
pub get failed (1; Because software depends on yaru >=0.4.0 which requires Flutter SDK version >=3.3.0, version solving failed.)
```