### PR TITLE
Add border-radius to carousel images

### DIFF
--- a/lib/store_app/common/media_tile.dart
+++ b/lib/store_app/common/media_tile.dart
@@ -31,30 +31,41 @@ class MediaTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(10),
-        excludeFromSemantics: true,
-        onTap: () => showDialog(
-          context: context,
-          builder: (context) => SimpleDialog(
-            children: [
-              InkWell(
-                onTap: () => Navigator.of(context).pop(),
-                child: YaruSafeImage(
-                  url: url,
-                  fit: fit,
-                  filterQuality: FilterQuality.medium,
-                  fallBackIconData: YaruIcons.image,
-                ),
-              )
-            ],
+    const borderRadius = BorderRadius.all(Radius.circular(10));
+    const padding = EdgeInsets.all(5);
+
+    return Center(
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: borderRadius.outer(padding),
+          excludeFromSemantics: true,
+          onTap: () => showDialog(
+            context: context,
+            builder: (context) => SimpleDialog(
+              children: [
+                InkWell(
+                  onTap: () => Navigator.of(context).pop(),
+                  child: YaruSafeImage(
+                    url: url,
+                    fit: fit,
+                    filterQuality: FilterQuality.medium,
+                    fallBackIconData: YaruIcons.image,
+                  ),
+                )
+              ],
+            ),
           ),
-        ),
-        child: YaruSafeImage(
-          url: url,
-          fallBackIconData: YaruIcons.image,
+          child: Padding(
+            padding: padding,
+            child: ClipRRect(
+              borderRadius: borderRadius,
+              child: YaruSafeImage(
+                url: url,
+                fallBackIconData: YaruIcons.image,
+              ),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION

[Capture vidéo du 21-09-2022 22:43:30.webm](https://user-images.githubusercontent.com/36476595/191606974-eecd7f07-7187-4412-9835-87d27b904b8f.webm)


- Add border-radius to carousel images ;
- Add little padding to InkWell (to clearly see the effect) ;
- Center the InkWell to avoid full width with small image inside.

Fixes #247