### PR TITLE
Updates: cut changelog after 4k chars

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -74,5 +74,7 @@
   "classic": "klassisch",
   "verified": "Verifizierter Herausgeber",
   "updatesComplete": "Aktualisierungen abgeschlossen",
-  "findOurRepository": "Finde uns auf GitHub"
+  "findOurRepository": "Finde uns auf GitHub",
+  "changelogTooLong": "Bitte besuchen Sie für das gesammte Änderungprotokoll:"
+
 } 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -74,5 +74,6 @@
   "classic": "classic",
   "verified": "Verified Publisher",
   "updatesComplete": "Updates complete",
-  "findOurRepository": "Find us on GitHub"
+  "findOurRepository": "Find us on GitHub",
+  "changelogTooLong": "For the full changelog, please visit:"
 } 

--- a/lib/store_app/updates/update_dialog.dart
+++ b/lib/store_app/updates/update_dialog.dart
@@ -71,23 +71,17 @@ class _UpdateDialogState extends State<UpdateDialog> {
     final caption = Theme.of(context).textTheme.bodySmall;
     return AlertDialog(
       title: YaruDialogTitle(
-        title: widget.id.name,
+        title: model.packageState != PackageState.ready ? null : widget.id.name,
         closeIconData: YaruIcons.window_close,
       ),
       titlePadding: EdgeInsets.zero,
       contentPadding: const EdgeInsets.only(left: 20, right: 20, bottom: 20),
       scrollable: true,
       content: model.packageState != PackageState.ready
-          ? Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(model.info != null ? model.info!.name : ''),
-                  YaruLinearProgressIndicator(
-                    value:
-                        model.percentage != null ? model.percentage! / 100 : 0,
-                  ),
-                ],
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.only(bottom: 40),
+                child: YaruCircularProgressIndicator(),
               ),
             )
           : SizedBox(
@@ -143,10 +137,16 @@ class _UpdateDialogState extends State<UpdateDialog> {
                       ),
                       expandIcon: const Icon(YaruIcons.pan_end),
                       isExpanded: true,
-                      child: SizedBox(
-                        height: 250,
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(
+                          maxHeight: 150,
+                          minHeight: 150,
+                        ),
+                        // height: 250,
                         child: Markdown(
-                          data: model.changelog,
+                          data: model.changelog.length > 4000
+                              ? '${model.changelog.substring(0, 4000)}\n\n ... ${context.l10n.changelogTooLong} ${model.url}'
+                              : model.changelog,
                           shrinkWrap: true,
                           selectable: true,
                           onTapLink: (text, href, title) =>


### PR DESCRIPTION
Some updates send their whole changelog and not only the latest changes over packagekit
This can kill the markdown inside the updates dialog.
Thus this cuts the changelog after 4k chars for now and links to the website after

![grafik](https://user-images.githubusercontent.com/15329494/191926669-671a2f31-8eef-4bf4-9d03-517373ebe808.png)
