### PR TITLE
fix: update localization default to english

### DIFF
--- a/lib/store_app/store_app.dart
+++ b/lib/store_app/store_app.dart
@@ -45,6 +45,19 @@ class StoreApp extends StatelessWidget {
         child: const StoreApp(),
       );
 
+  /// Returns a preferred [Locale] if present in [supportedLocales].
+  ///
+  /// If [deviceLocales] contains no supported locales, defaults to English.
+  Locale _resolveLocale(deviceLocales, supportedLocales) {
+    var locale = basicLocaleListResolution(deviceLocales, supportedLocales);
+    if (locale == supportedLocales.first && deviceLocales != null) {
+      if (!deviceLocales.contains(locale)) {
+        return const Locale('en');
+      }
+    }
+    return locale;
+  }
+
   @override
   Widget build(BuildContext context) {
     return YaruTheme(
@@ -57,6 +70,7 @@ class StoreApp extends StatelessWidget {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           onGenerateTitle: (context) => context.l10n.appTitle,
+          localeListResolutionCallback: _resolveLocale,
           routes: {
             Navigator.defaultRouteName: (context) {
               return const Scaffold(

--- a/lib/store_app/store_app.dart
+++ b/lib/store_app/store_app.dart
@@ -48,7 +48,10 @@ class StoreApp extends StatelessWidget {
   /// Returns a preferred [Locale] if present in [supportedLocales].
   ///
   /// If [deviceLocales] contains no supported locales, defaults to English.
-  Locale _resolveLocale(deviceLocales, supportedLocales) {
+  Locale _resolveLocale(
+    List<Locale>? deviceLocales,
+    Iterable<Locale> supportedLocales,
+  ) {
     var locale = basicLocaleListResolution(deviceLocales, supportedLocales);
     if (locale == supportedLocales.first && deviceLocales != null) {
       if (!deviceLocales.contains(locale)) {

--- a/lib/store_app/store_app.dart
+++ b/lib/store_app/store_app.dart
@@ -53,12 +53,11 @@ class StoreApp extends StatelessWidget {
     Iterable<Locale> supportedLocales,
   ) {
     var locale = basicLocaleListResolution(deviceLocales, supportedLocales);
-    if (locale == supportedLocales.first && deviceLocales != null) {
-      if (!deviceLocales.contains(locale)) {
-        return const Locale('en');
-      }
+    if (deviceLocales != null && deviceLocales.contains(locale)) {
+      return locale;
+    } else {
+      return const Locale('en');
     }
-    return locale;
   }
 
   @override


### PR DESCRIPTION
I added function that tries to resolve the current locale using the default functionality already present. Additionally it also checks if:
- the locale was the first in the list of supported locales,
- the locale is not present in the device locales.

If both checks pass, it returns the English locale instead.

Unfortunately I was not able to replicate the exact bug listed in #216, though I did test this on a couple of machines and it seemed to work. @AdamSzopa could you confirm if this fixes the issue on your end?

closes #216