### PR TITLE
Reuse disabledColor for noNetwork animated icon

### DIFF
--- a/lib/store_app/common/offline_page.dart
+++ b/lib/store_app/common/offline_page.dart
@@ -28,11 +28,9 @@ class OfflinePage extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const YaruAnimatedNoNetworkIcon(
+          YaruAnimatedNoNetworkIcon(
             size: 200,
-            // TODO: use disabledColor once yaru_icons.dart#62 is fixed
-            // color: Theme.of(context).disabledColor,
-            color: Colors.grey,
+            color: Theme.of(context).disabledColor,
           ),
           Text(
             context.l10n.offline,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -578,7 +578,7 @@ packages:
       name: yaru_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   yaru_widgets:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   window_manager: ^0.2.6
   yaru: ^0.4.1
   yaru_colors: ^0.1.0
-  yaru_icons: ^0.2.3
+  yaru_icons: ^0.2.4
   yaru_widgets: ^1.1.4
 
 dev_dependencies:


### PR DESCRIPTION

![Capture d’écran du 2022-10-01 14-10-53](https://user-images.githubusercontent.com/36476595/193408975-36a341bc-c35e-43ca-99a3-32699ed58d5d.png)


Fixes #336

Related to #233 #73