### PR TITLE
Prevent update interruptions more gracefully on app close

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -78,7 +78,12 @@
   "verified": "Verifizierter Herausgeber",
   "updatesComplete": "Aktualisierungen abgeschlossen",
   "findOurRepository": "Finde uns auf GitHub",
-  "changelogTooLong": "Bitte besuchen Sie für das gesammte Änderungprotokoll:",
+  "changelogTooLong": "Bitte besuchen Sie für das gesamte Änderungsprotokoll:",
   "noPackageFound": "Es tut uns leid, aber wir konnten mit diesem Suchbegriff kein Paket finden",
-  "noSnapFound": "Es tut uns leid, aber wir konnten mit diesem Suchbegriff keine Snap finden"
+  "noSnapFound": "Es tut uns leid, aber wir konnten mit diesem Suchbegriff keine Snap finden",
+  "cancel": "Abbrechen",
+  "confirm": "Bestätigen",
+  "runsInBackground": "Ubuntu Software läuft im Hintergrund weiter, um das System auf Aktualisierungen zu prüfen.",
+  "quit": "Beenden",
+  "quitDanger": "Achtung! Momentan werden Systemaktualisierungen durchgeführt. Wenn das Programm jetzt geschlossen wird, könnte Ihr System beschädigt werden!"
 } 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -80,5 +80,10 @@
   "findOurRepository": "Find us on GitHub",
   "changelogTooLong": "For the full changelog, please visit:",
   "noPackageFound": "Sorry, we couldn't find any package with this search query",
-  "noSnapFound": "Sorry, we couldn't find any snap with this search query"
+  "noSnapFound": "Sorry, we couldn't find any snap with this search query",
+  "cancel": "Cancel",
+  "confirm": "Confirm",
+  "runsInBackground": "Ubuntu Software keeps running in the background to check for system updates.",
+  "quit": "Quit",
+  "quitDanger": "Attention! System updates are currently running. Quitting the App now could leave your system in a damaged state!"
 } 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,8 @@ import 'package:window_manager/window_manager.dart';
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
   await windowManager.ensureInitialized();
+  windowManager.setPreventClose(true);
+  windowManager.addListener(MyWindowListener());
 
   registerService<NotificationsClient>(
     NotificationsClient.new,
@@ -66,4 +68,52 @@ void main(List<String> args) async {
       PackageInstallerApp(path: path),
     );
   }
+}
+
+class MyWindowListener implements WindowListener {
+  @override
+  void onWindowBlur() {}
+
+  @override
+  void onWindowClose() {
+    /// To check for updates even in the background, we hide the window on app close.
+    /// The App is still closeable from the settings page.
+    windowManager.hide();
+  }
+
+  @override
+  void onWindowEnterFullScreen() {}
+
+  @override
+  void onWindowEvent(String eventName) {}
+
+  @override
+  void onWindowFocus() {}
+
+  @override
+  void onWindowLeaveFullScreen() {}
+
+  @override
+  void onWindowMaximize() {}
+
+  @override
+  void onWindowMinimize() {}
+
+  @override
+  void onWindowMove() {}
+
+  @override
+  void onWindowMoved() {}
+
+  @override
+  void onWindowResize() {}
+
+  @override
+  void onWindowResized() {}
+
+  @override
+  void onWindowRestore() {}
+
+  @override
+  void onWindowUnmaximize() {}
 }

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -22,11 +22,11 @@ import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:intl/intl.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:software/package_state.dart';
+import 'package:software/store_app/common/constants.dart';
 import 'package:software/store_app/common/utils.dart';
 import 'package:software/updates_state.dart';
 import 'package:synchronized/extension.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:window_manager/window_manager.dart';
 
 class PackageService {
   final PackageKitClient _client;
@@ -247,20 +247,17 @@ class PackageService {
   }
 
   Future<void> refreshUpdates() async {
-    windowManager.setClosable(false);
-    try {
-      setErrorMessage('');
-      setUpdatesState(UpdatesState.checkingForUpdates);
-      await _loadRepoList();
-      await _refreshCache();
-      await _getUpdates();
-      setUpdatesState(
-        _updates.isEmpty ? UpdatesState.noUpdates : UpdatesState.readyToUpdate,
-      );
-    } finally {
-      windowManager.setClosable(true);
-    }
-    _refreshUpdatesTimer = Timer.periodic(const Duration(minutes: 30), (timer) {
+    setErrorMessage('');
+    setUpdatesState(UpdatesState.checkingForUpdates);
+    await _loadRepoList();
+    await _refreshCache();
+    await _getUpdates();
+    setUpdatesState(
+      _updates.isEmpty ? UpdatesState.noUpdates : UpdatesState.readyToUpdate,
+    );
+
+    _refreshUpdatesTimer = Timer.periodic(
+        const Duration(minutes: kCheckForUpdateTimeOutInMinutes), (timer) {
       if (lastUpdatesState == UpdatesState.noUpdates) {
         refreshUpdates();
       }
@@ -319,59 +316,54 @@ class PackageService {
   }
 
   Future<void> updateAll({required String updatesComplete}) async {
-    windowManager.setClosable(false);
-    try {
-      setErrorMessage('');
-      final List<PackageKitPackageId> selectedUpdates = _updates.entries
-          .where((e) => e.value == true)
-          .map((e) => e.key)
-          .toList();
-      if (selectedUpdates.isEmpty) return;
-      final updatePackagesTransaction = await _client.createTransaction();
-      final updatePackagesCompleter = Completer();
-      setUpdatesState(UpdatesState.updating);
-      updatePackagesTransaction.events.listen((event) {
-        if (event is PackageKitRequireRestartEvent) {
-          setRequireRestart(event.type);
-        }
-        if (event is PackageKitPackageEvent) {
-          setProcessedId(event.packageId);
-          setInfo(event.info);
-        } else if (event is PackageKitItemProgressEvent) {
-          setUpdatePercentage(event.percentage);
-          setProcessedId(event.packageId);
-          setStatus(event.status);
-        } else if (event is PackageKitErrorCodeEvent) {
-          setErrorMessage('${event.code}: ${event.details}');
-        } else if (event is PackageKitFinishedEvent) {
-          updatePackagesCompleter.complete();
-        }
-      });
-      await updatePackagesTransaction.updatePackages(selectedUpdates);
-      await updatePackagesCompleter.future;
-      _updates.clear();
-      setInfo(null);
-      setStatus(null);
-      setProcessedId(null);
-      setUpdatePercentage(null);
-      if (selectedUpdates.length == updates.length) {
-        setUpdatesState(UpdatesState.noUpdates);
-      } else {
-        await refreshUpdates();
+    setErrorMessage('');
+    final List<PackageKitPackageId> selectedUpdates = _updates.entries
+        .where((e) => e.value == true)
+        .map((e) => e.key)
+        .toList();
+    if (selectedUpdates.isEmpty) return;
+    final updatePackagesTransaction = await _client.createTransaction();
+    final updatePackagesCompleter = Completer();
+    setUpdatesState(UpdatesState.updating);
+    updatePackagesTransaction.events.listen((event) {
+      if (event is PackageKitRequireRestartEvent) {
+        setRequireRestart(event.type);
       }
-      _notificationsClient.notify(
-        'Ubuntu Software',
-        body: updatesComplete,
-        appName: 'snap-store',
-        appIcon: 'snap-store',
-        hints: [
-          NotificationHint.desktopEntry('software'),
-          NotificationHint.urgency(NotificationUrgency.normal)
-        ],
-      );
-    } finally {
-      windowManager.setClosable(true);
+      if (event is PackageKitPackageEvent) {
+        setProcessedId(event.packageId);
+        setInfo(event.info);
+      } else if (event is PackageKitItemProgressEvent) {
+        setUpdatePercentage(event.percentage);
+        setProcessedId(event.packageId);
+        setStatus(event.status);
+      } else if (event is PackageKitErrorCodeEvent) {
+        setErrorMessage('${event.code}: ${event.details}');
+      } else if (event is PackageKitFinishedEvent) {
+        updatePackagesCompleter.complete();
+      }
+    });
+    await updatePackagesTransaction.updatePackages(selectedUpdates);
+    await updatePackagesCompleter.future;
+    _updates.clear();
+    setInfo(null);
+    setStatus(null);
+    setProcessedId(null);
+    setUpdatePercentage(null);
+    if (selectedUpdates.length == updates.length) {
+      setUpdatesState(UpdatesState.noUpdates);
+    } else {
+      await refreshUpdates();
     }
+    _notificationsClient.notify(
+      'Ubuntu Software',
+      body: updatesComplete,
+      appName: 'snap-store',
+      appIcon: 'snap-store',
+      hints: [
+        NotificationHint.desktopEntry('software'),
+        NotificationHint.urgency(NotificationUrgency.normal)
+      ],
+    );
   }
 
   Future<void> _getInstalledPackages() async {

--- a/lib/store_app/common/confirmation_dialog.dart
+++ b/lib/store_app/common/confirmation_dialog.dart
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'package:flutter/material.dart';
+import 'package:software/l10n/l10n.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class ConfirmationDialog extends StatefulWidget {
+  const ConfirmationDialog({
+    Key? key,
+    this.onConfirm,
+    required this.iconData,
+    this.title,
+    this.message,
+    this.positiveConfirm = true,
+  }) : super(key: key);
+
+  final Function()? onConfirm;
+  final IconData iconData;
+  final String? title;
+  final String? message;
+  final bool positiveConfirm;
+
+  @override
+  State<ConfirmationDialog> createState() => _ConfirmationDialogState();
+}
+
+class _ConfirmationDialogState extends State<ConfirmationDialog>
+    with SingleTickerProviderStateMixin {
+  late AnimationController controller;
+  late Animation sizeAnimation;
+  late Animation colorAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    controller =
+        AnimationController(vsync: this, duration: const Duration(seconds: 2));
+    sizeAnimation = Tween<double>(begin: 100.0, end: 400.0).animate(controller);
+    colorAnimation =
+        ColorTween(begin: Colors.red, end: Colors.red.withOpacity(0.2))
+            .animate(controller);
+    controller.addListener(() {
+      setState(() {});
+    });
+    controller.repeat();
+  }
+
+  @override
+  void dispose() {
+    controller.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialog(
+      titlePadding: EdgeInsets.zero,
+      title: YaruDialogTitle(
+        mainAxisAlignment: MainAxisAlignment.center,
+        closeIconData: YaruIcons.window_close,
+        title: widget.title,
+      ),
+      contentPadding: EdgeInsets.zero,
+      children: [
+        if (widget.message != null)
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: SizedBox(
+              width: 500,
+              child: Text(
+                widget.message!,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            ),
+          ),
+        Icon(
+          widget.iconData,
+          size: 100,
+          color: colorAnimation.value,
+        ),
+        const SizedBox(
+          height: 40,
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: SizedBox(
+            width: 500 / 3,
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(
+                      context.l10n.cancel,
+                      style: TextStyle(color: Theme.of(context).errorColor),
+                    ),
+                  ),
+                ),
+                const SizedBox(
+                  width: 8,
+                ),
+                Expanded(
+                  child: widget.positiveConfirm
+                      ? ElevatedButton(
+                          onPressed: widget.onConfirm,
+                          child: Text(
+                            context.l10n.confirm,
+                          ),
+                        )
+                      : OutlinedButton(
+                          onPressed: widget.onConfirm,
+                          child: Text(
+                            context.l10n.confirm,
+                          ),
+                        ),
+                )
+              ],
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/store_app/common/constants.dart
+++ b/lib/store_app/common/constants.dart
@@ -27,3 +27,4 @@ const kGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
 );
 const positiveGreenLightTheme = Color.fromARGB(255, 51, 121, 63);
 const positiveGreenDarkTheme = Color.fromARGB(255, 128, 211, 143);
+const kCheckForUpdateTimeOutInMinutes = 30;

--- a/lib/store_app/settings/settings_model.dart
+++ b/lib/store_app/settings/settings_model.dart
@@ -17,10 +17,15 @@
 
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:software/services/package_service.dart';
+import 'package:software/updates_state.dart';
+import 'package:window_manager/window_manager.dart';
 
 const repoUrl = 'https://github.com/ubuntu-flutter-community/software';
 
 class SettingsModel extends SafeChangeNotifier {
+  final PackageService _packageService;
+
   String appName;
 
   String packageName;
@@ -28,7 +33,7 @@ class SettingsModel extends SafeChangeNotifier {
   String version;
 
   String buildNumber;
-  SettingsModel()
+  SettingsModel(this._packageService)
       : appName = '',
         packageName = '',
         version = '',
@@ -42,4 +47,13 @@ class SettingsModel extends SafeChangeNotifier {
     buildNumber = packageInfo.buildNumber;
     notifyListeners();
   }
+
+  void quit() {
+    windowManager.setPreventClose(false);
+    windowManager.close();
+  }
+
+  bool get isUpdateRunning =>
+      _packageService.lastUpdatesState == UpdatesState.updating ||
+      _packageService.lastUpdatesState == UpdatesState.checkingForUpdates;
 }

--- a/lib/store_app/updates/updates_page.dart
+++ b/lib/store_app/updates/updates_page.dart
@@ -263,20 +263,10 @@ class _UpdatesHeader extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  model.updatesState == UpdatesState.noUpdates ||
-                          model.updatesState == UpdatesState.readyToUpdate ||
-                          model.updatesState == null
-                      ? const Icon(
-                          YaruIcons.refresh,
-                          size: 18,
-                        )
-                      : const SizedBox(
-                          height: 16,
-                          width: 16,
-                          child: YaruCircularProgressIndicator(
-                            strokeWidth: 2,
-                          ),
-                        ),
+                  const Icon(
+                    YaruIcons.refresh,
+                    size: 18,
+                  ),
                   const SizedBox(
                     width: 5,
                   ),


### PR DESCRIPTION
This removes the disabling of the window controls on update checking and updating.
Instead we hide the window by default on close. If the user wants to quit the app there is a new row in the settings page to do so.
If updates are currently running a confirmation dialogue will ask again if the user really wants to quit.

This hiding also has the advantage of preserving the 30 minutes update checker in the background. We need also a notification if updates are available but this can be done in a different PR.

![grafik](https://user-images.githubusercontent.com/15329494/193602122-e0cc02c9-2f00-4990-acac-e956b10ec30a.png)


Fixes #235