### PR TITLE
Upgrade ubuntu_session

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,10 +47,7 @@ void main(List<String> args) async {
     PackageService.new,
     dispose: (s) => s.dispose(),
   );
-  registerService<SessionManager>(
-    SessionManager.new,
-    dispose: (s) => s.close(),
-  );
+  registerService<UbuntuSession>(UbuntuSession.new);
 
   final loadPackageInstaller =
       args.isNotEmpty && args.any((arg) => arg.endsWith('.deb'));

--- a/lib/store_app/updates/updates_model.dart
+++ b/lib/store_app/updates/updates_model.dart
@@ -25,7 +25,7 @@ import 'package:ubuntu_session/ubuntu_session.dart';
 
 class UpdatesModel extends SafeChangeNotifier {
   final PackageService _service;
-  final SessionManager _sessionManager;
+  final UbuntuSession _session;
   StreamSubscription<String>? _errorMessageSub;
   StreamSubscription<PackageKitRestart>? _requireRestartSub;
   StreamSubscription<int?>? _percentageSub;
@@ -41,7 +41,7 @@ class UpdatesModel extends SafeChangeNotifier {
 
   UpdatesModel(
     this._service,
-    this._sessionManager,
+    this._session,
   )   : _requireRestart = PackageKitRestart.none,
         _errorMessage = '',
         _manualRepoName = '';
@@ -219,7 +219,7 @@ class UpdatesModel extends SafeChangeNotifier {
     await _service.toggleRepo(id: id, value: value);
   }
 
-  void reboot() => _sessionManager.reboot();
+  void reboot() => _session.reboot();
 
   void logout() => _service.logout();
 

--- a/lib/store_app/updates/updates_page.dart
+++ b/lib/store_app/updates/updates_page.dart
@@ -38,7 +38,7 @@ class UpdatesPage extends StatefulWidget {
     return ChangeNotifierProvider(
       create: (_) => UpdatesModel(
         getService<PackageService>(),
-        getService<SessionManager>(),
+        getService<UbuntuSession>(),
       ),
       child: const UpdatesPage(),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -466,7 +466,7 @@ packages:
       name: ubuntu_session
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   snapd: ^0.4.6
   synchronized: ^3.0.0+3
   ubuntu_service: ^0.2.0
-  ubuntu_session: 0.0.1
+  ubuntu_session: ^0.0.2
   url_launcher: ^6.1.2
   version: ^3.0.2
   window_manager: ^0.2.6


### PR DESCRIPTION
The GNOME-specific SessionManager was renamed to GnomeSessionManager and a new simplified API was made available as UbuntuSession named after the package. Later on, the common UbuntuSession API will be implemented for a variety of flavors and desktops.