### PR TITLE
ExplorePage: filter field section icon color

### DIFF
--- a/lib/store_app/explore/search_field.dart
+++ b/lib/store_app/explore/search_field.dart
@@ -118,7 +118,10 @@ class _SectionDropdown extends StatelessWidget {
       tooltip: context.l10n.filterSnaps,
       splashRadius: 20,
       onSelected: onChanged,
-      icon: Icon(snapSectionToIcon[value]),
+      icon: Icon(
+        snapSectionToIcon[value],
+        color: Theme.of(context).primaryColor,
+      ),
       initialValue: SnapSection.all,
       itemBuilder: (context) {
         return [


### PR DESCRIPTION
- make the icon use primary color to indicate that this icon is interactive to set the section filter

![grafik](https://user-images.githubusercontent.com/15329494/196638617-414dde6e-cd8c-461c-a3ac-1e9df1074d53.png)
