### PR TITLE
Move the snap filter to the search page

### DIFF
--- a/lib/store_app/common/app_format_button.dart
+++ b/lib/store_app/common/app_format_button.dart
@@ -18,44 +18,43 @@
 import 'package:flutter/material.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/store_app/common/app_format.dart';
+import 'package:software/store_app/common/drop_down_decoration.dart';
 
 class AppFormatButton extends StatelessWidget {
   const AppFormatButton({
     super.key,
-    this.onPressed,
+    required this.onPressed,
     required this.appFormat,
-    required this.selected,
   });
 
-  final void Function()? onPressed;
+  final void Function(AppFormat appFormat) onPressed;
   final AppFormat appFormat;
-  final bool selected;
 
   @override
   Widget build(BuildContext context) {
-    final color = selected
-        ? Theme.of(context).primaryColor
-        : Theme.of(context).colorScheme.onSurface.withOpacity(0.7);
-    return OutlinedButton(
-      onPressed: onPressed,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            appFormatToIconData[appFormat],
-            size: 15,
-            color: color,
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(6),
+      child: Material(
+        color: Colors.transparent,
+        child: PopupMenuButton(
+          initialValue: appFormat,
+          itemBuilder: (context) {
+            return [
+              for (var appFormat in AppFormat.values)
+                PopupMenuItem(
+                  value: appFormat,
+                  onTap: () => onPressed(appFormat),
+                  child: Text(
+                    appFormat.localize(context.l10n),
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                )
+            ];
+          },
+          child: DropDownDecoration(
+            child: Text(appFormat.localize(context.l10n)),
           ),
-          const SizedBox(
-            width: 5,
-          ),
-          Text(
-            appFormat.localize(context.l10n),
-            style: TextStyle(
-              color: color,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/store_app/common/drop_down_decoration.dart
+++ b/lib/store_app/common/drop_down_decoration.dart
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'package:flutter/material.dart';
+import 'package:yaru_icons/yaru_icons.dart';
+
+class DropDownDecoration extends StatelessWidget {
+  const DropDownDecoration({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: Theme.of(context).dividerColor),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              height: 40,
+              child: Icon(
+                YaruIcons.pan_down,
+                size: 20,
+              ),
+            ),
+            const SizedBox(
+              width: 5,
+            ),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/store_app/common/snap_channel_button.dart
+++ b/lib/store_app/common/snap_channel_button.dart
@@ -21,8 +21,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:software/l10n/l10n.dart';
+import 'package:software/store_app/common/drop_down_decoration.dart';
 import 'package:software/store_app/common/snap_model.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 class SnapChannelPopupButton extends StatelessWidget {
   const SnapChannelPopupButton({
@@ -80,24 +80,8 @@ class SnapChannelPopupButton extends StatelessWidget {
                 )
             ];
           },
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(6),
-              border: Border.all(color: Theme.of(context).dividerColor),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(model.channelToBeInstalled),
-                  const SizedBox(
-                    height: 40,
-                    child: Icon(YaruIcons.pan_down),
-                  ),
-                ],
-              ),
-            ),
+          child: DropDownDecoration(
+            child: Text(model.channelToBeInstalled),
           ),
         ),
       ),

--- a/lib/store_app/common/snap_section_dropdown.dart
+++ b/lib/store_app/common/snap_section_dropdown.dart
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'package:flutter/material.dart';
+import 'package:software/l10n/l10n.dart';
+import 'package:software/store_app/common/drop_down_decoration.dart';
+import 'package:software/store_app/common/snap_section.dart';
+
+class SectionDropdown extends StatelessWidget {
+  const SectionDropdown({
+    // ignore: unused_element
+    super.key,
+    required this.value,
+    this.onChanged,
+  });
+
+  final SnapSection value;
+  final Function(SnapSection?)? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(6),
+      child: Material(
+        color: Colors.transparent,
+        child: PopupMenuButton<SnapSection>(
+          tooltip: context.l10n.filterSnaps,
+          splashRadius: 20,
+          onSelected: onChanged,
+          initialValue: SnapSection.all,
+          itemBuilder: (context) {
+            return [
+              for (final section in SnapSection.values)
+                PopupMenuItem(
+                  value: section,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SizedBox(
+                        width: 5,
+                      ),
+                      SizedBox(
+                        width: 20,
+                        child: Icon(
+                          snapSectionToIcon[section],
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.8),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          section.localize(
+                            context.l10n,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      )
+                    ],
+                  ),
+                )
+            ];
+          },
+          child: DropDownDecoration(child: Text(value.localize(context.l10n))),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/store_app/explore/explore_model.dart
+++ b/lib/store_app/explore/explore_model.dart
@@ -186,7 +186,7 @@ class ExploreModel extends SafeChangeNotifier {
 
   AppFormat _appFormat = AppFormat.snap;
   AppFormat get appFormat => _appFormat;
-  set appFormat(AppFormat value) {
+  void setAppFormat(AppFormat value) {
     if (value == _appFormat) return;
     _appFormat = value;
     notifyListeners();

--- a/lib/store_app/explore/search_field.dart
+++ b/lib/store_app/explore/search_field.dart
@@ -104,68 +104,64 @@ class SectionDropdown extends StatelessWidget {
     super.key,
     required this.value,
     this.onChanged,
-    this.useText = false,
   });
 
   final SnapSection value;
   final Function(SnapSection?)? onChanged;
-  final bool useText;
 
   @override
   Widget build(BuildContext context) {
-    return PopupMenuButton<SnapSection>(
-      tooltip: context.l10n.filterSnaps,
-      splashRadius: 20,
-      onSelected: onChanged,
-      icon: useText
-          ? null
-          : Icon(
-              snapSectionToIcon[value],
-              color: Theme.of(context).primaryColor,
-            ),
-      initialValue: SnapSection.all,
-      itemBuilder: (context) {
-        return [
-          for (final section in SnapSection.values)
-            PopupMenuItem(
-              value: section,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SizedBox(
-                    width: 5,
-                  ),
-                  SizedBox(
-                    width: 20,
-                    child: Icon(
-                      snapSectionToIcon[section],
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withOpacity(0.8),
-                    ),
-                  ),
-                  const SizedBox(
-                    width: 10,
-                  ),
-                  Expanded(
-                    flex: 1,
-                    child: Text(
-                      section.localize(
-                        context.l10n,
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(6),
+      child: Material(
+        color: Colors.transparent,
+        child: PopupMenuButton<SnapSection>(
+          tooltip: context.l10n.filterSnaps,
+          splashRadius: 20,
+          onSelected: onChanged,
+          initialValue: SnapSection.all,
+          itemBuilder: (context) {
+            return [
+              for (final section in SnapSection.values)
+                PopupMenuItem(
+                  value: section,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SizedBox(
+                        width: 5,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  )
-                ],
-              ),
-            )
-        ];
-      },
-      child: useText
-          ? DropDownDecoration(child: Text(value.localize(context.l10n)))
-          : null,
+                      SizedBox(
+                        width: 20,
+                        child: Icon(
+                          snapSectionToIcon[section],
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withOpacity(0.8),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      Expanded(
+                        flex: 1,
+                        child: Text(
+                          section.localize(
+                            context.l10n,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      )
+                    ],
+                  ),
+                )
+            ];
+          },
+          child: DropDownDecoration(child: Text(value.localize(context.l10n))),
+        ),
+      ),
     );
   }
 }

--- a/lib/store_app/explore/search_field.dart
+++ b/lib/store_app/explore/search_field.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:software/l10n/l10n.dart';
+import 'package:software/store_app/common/drop_down_decoration.dart';
 import 'package:software/store_app/common/snap_section.dart';
 import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -62,18 +63,14 @@ class _SearchFieldState extends State<SearchField> {
         },
         textInputAction: TextInputAction.send,
         decoration: InputDecoration(
-          hintText: model.selectedSection.localize(context.l10n),
-          prefixIcon: Padding(
-            padding: const EdgeInsets.only(left: 10, right: 5),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _SectionDropdown(
-                  value: model.selectedSection,
-                  onChanged: (v) => model.selectedSection = v!,
-                ),
-              ],
-            ),
+          hintText: context.l10n.searchHint,
+          prefixIcon: const Icon(
+            YaruIcons.search,
+            size: 20,
+          ),
+          prefixIconConstraints: const BoxConstraints(
+            minHeight: 45,
+            minWidth: 40,
           ),
           isDense: false,
           border: const UnderlineInputBorder(),
@@ -101,16 +98,18 @@ class _SearchFieldState extends State<SearchField> {
   }
 }
 
-class _SectionDropdown extends StatelessWidget {
-  const _SectionDropdown({
+class SectionDropdown extends StatelessWidget {
+  const SectionDropdown({
     // ignore: unused_element
     super.key,
     required this.value,
     this.onChanged,
+    this.useText = false,
   });
 
   final SnapSection value;
   final Function(SnapSection?)? onChanged;
+  final bool useText;
 
   @override
   Widget build(BuildContext context) {
@@ -118,10 +117,12 @@ class _SectionDropdown extends StatelessWidget {
       tooltip: context.l10n.filterSnaps,
       splashRadius: 20,
       onSelected: onChanged,
-      icon: Icon(
-        snapSectionToIcon[value],
-        color: Theme.of(context).primaryColor,
-      ),
+      icon: useText
+          ? null
+          : Icon(
+              snapSectionToIcon[value],
+              color: Theme.of(context).primaryColor,
+            ),
       initialValue: SnapSection.all,
       itemBuilder: (context) {
         return [
@@ -162,6 +163,9 @@ class _SectionDropdown extends StatelessWidget {
             )
         ];
       },
+      child: useText
+          ? DropDownDecoration(child: Text(value.localize(context.l10n)))
+          : null,
     );
   }
 }

--- a/lib/store_app/explore/search_field.dart
+++ b/lib/store_app/explore/search_field.dart
@@ -19,7 +19,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/drop_down_decoration.dart';
 import 'package:software/store_app/common/snap_section.dart';
 import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -92,74 +91,6 @@ class _SearchFieldState extends State<SearchField> {
                   ),
                 )
               : null,
-        ),
-      ),
-    );
-  }
-}
-
-class SectionDropdown extends StatelessWidget {
-  const SectionDropdown({
-    // ignore: unused_element
-    super.key,
-    required this.value,
-    this.onChanged,
-  });
-
-  final SnapSection value;
-  final Function(SnapSection?)? onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(6),
-      child: Material(
-        color: Colors.transparent,
-        child: PopupMenuButton<SnapSection>(
-          tooltip: context.l10n.filterSnaps,
-          splashRadius: 20,
-          onSelected: onChanged,
-          initialValue: SnapSection.all,
-          itemBuilder: (context) {
-            return [
-              for (final section in SnapSection.values)
-                PopupMenuItem(
-                  value: section,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const SizedBox(
-                        width: 5,
-                      ),
-                      SizedBox(
-                        width: 20,
-                        child: Icon(
-                          snapSectionToIcon[section],
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onSurface
-                              .withOpacity(0.8),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 10,
-                      ),
-                      Expanded(
-                        flex: 1,
-                        child: Text(
-                          section.localize(
-                            context.l10n,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      )
-                    ],
-                  ),
-                )
-            ];
-          },
-          child: DropDownDecoration(child: Text(value.localize(context.l10n))),
         ),
       ),
     );

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -27,6 +27,7 @@ import 'package:software/store_app/common/app_format_button.dart';
 import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
 import 'package:software/store_app/explore/explore_model.dart';
+import 'package:software/store_app/explore/search_field.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -49,12 +50,16 @@ class SearchPage extends StatelessWidget {
               runAlignment: WrapAlignment.start,
               spacing: 10,
               children: [
-                for (final appFormat in AppFormat.values)
-                  AppFormatButton(
-                    appFormat: appFormat,
-                    selected: model.appFormat == appFormat,
-                    onPressed: () => model.appFormat = appFormat,
-                  ),
+                AppFormatButton(
+                  appFormat: model.appFormat,
+                  onPressed: model.setAppFormat,
+                ),
+                if (model.appFormat == AppFormat.snap)
+                  SectionDropdown(
+                    value: model.selectedSection,
+                    onChanged: (v) => model.selectedSection = v!,
+                    useText: true,
+                  )
               ],
             ),
           ),

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -58,7 +58,6 @@ class SearchPage extends StatelessWidget {
                   SectionDropdown(
                     value: model.selectedSection,
                     onChanged: (v) => model.selectedSection = v!,
-                    useText: true,
                   )
               ],
             ),

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -26,8 +26,8 @@ import 'package:software/store_app/common/app_format.dart';
 import 'package:software/store_app/common/app_format_button.dart';
 import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
+import 'package:software/store_app/common/snap_section_dropdown.dart';
 import 'package:software/store_app/explore/explore_model.dart';
-import 'package:software/store_app/explore/search_field.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -41,7 +41,7 @@ class SearchPage extends StatelessWidget {
     return Column(
       children: [
         Padding(
-          padding: const EdgeInsets.only(top: 25, left: 25),
+          padding: const EdgeInsets.only(top: 20, left: 25),
           child: Align(
             alignment: Alignment.centerLeft,
             child: Wrap(

--- a/lib/store_app/my_apps/my_apps_model.dart
+++ b/lib/store_app/my_apps/my_apps_model.dart
@@ -103,7 +103,7 @@ class MyAppsModel extends SafeChangeNotifier {
 
   AppFormat _appFormat = AppFormat.snap;
   AppFormat get appFormat => _appFormat;
-  set appFormat(AppFormat value) {
+  void setAppFormat(AppFormat value) {
     if (value == _appFormat) return;
     _appFormat = value;
     notifyListeners();

--- a/lib/store_app/my_apps/my_apps_page.dart
+++ b/lib/store_app/my_apps/my_apps_page.dart
@@ -67,7 +67,7 @@ class MyAppsPage extends StatelessWidget {
     final page = Column(
       children: [
         Padding(
-          padding: const EdgeInsets.only(top: 25, left: 25),
+          padding: const EdgeInsets.only(top: 20, left: 25),
           child: Align(
             alignment: Alignment.centerLeft,
             child: Wrap(

--- a/lib/store_app/my_apps/my_apps_page.dart
+++ b/lib/store_app/my_apps/my_apps_page.dart
@@ -76,12 +76,10 @@ class MyAppsPage extends StatelessWidget {
               runAlignment: WrapAlignment.start,
               spacing: 10,
               children: [
-                for (final appFormat in AppFormat.values)
-                  AppFormatButton(
-                    appFormat: appFormat,
-                    selected: model.appFormat == appFormat,
-                    onPressed: () => model.appFormat = appFormat,
-                  ),
+                AppFormatButton(
+                  appFormat: model.appFormat,
+                  onPressed: model.setAppFormat,
+                ),
               ],
             ),
           ),

--- a/lib/store_app/my_apps/my_snaps_page.dart
+++ b/lib/store_app/my_apps/my_snaps_page.dart
@@ -102,35 +102,38 @@ class __MySnapsGridState extends State<_MySnapsGrid> {
         child: YaruCircularProgressIndicator(),
       );
     }
-    return GridView.builder(
-      controller: _controller,
-      padding: const EdgeInsets.all(20.0),
-      gridDelegate: kGridDelegate,
-      shrinkWrap: true,
-      itemCount: widget.snaps.length,
-      itemBuilder: (context, index) {
-        final snap = widget.snaps.elementAt(index);
-        return AnimatedScrollViewItem(
-          child: YaruBanner(
-            title: Text(
-              snap.name,
-              overflow: TextOverflow.ellipsis,
-            ),
-            subtitle: Text(
-              snap.summary,
-              overflow: TextOverflow.ellipsis,
-            ),
-            icon: Padding(
-              padding:
-                  const EdgeInsets.only(left: 8, top: 8, bottom: 8, right: 5),
-              child: AppIcon(
-                iconUrl: snap.iconUrl,
+    return Padding(
+      padding: const EdgeInsets.only(top: 20),
+      child: GridView.builder(
+        controller: _controller,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        gridDelegate: kGridDelegate,
+        shrinkWrap: true,
+        itemCount: widget.snaps.length,
+        itemBuilder: (context, index) {
+          final snap = widget.snaps.elementAt(index);
+          return AnimatedScrollViewItem(
+            child: YaruBanner(
+              title: Text(
+                snap.name,
+                overflow: TextOverflow.ellipsis,
               ),
+              subtitle: Text(
+                snap.summary,
+                overflow: TextOverflow.ellipsis,
+              ),
+              icon: Padding(
+                padding:
+                    const EdgeInsets.only(left: 8, top: 8, bottom: 8, right: 5),
+                child: AppIcon(
+                  iconUrl: snap.iconUrl,
+                ),
+              ),
+              onTap: () => model.selectedSnap = snap,
             ),
-            onTap: () => model.selectedSnap = snap,
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
This moves the snap section filter dropdown out of the search bar into the search page.
This is also better for the future, when we might add more filters, that are dependant on the app format (snap/packagekit)

![grafik](https://user-images.githubusercontent.com/15329494/196716224-7fd1544a-05b6-4a89-8bd0-fef6dfcad706.png)
![grafik](https://user-images.githubusercontent.com/15329494/196716379-bbae61a0-f108-488b-bd30-00934e471439.png)
![grafik](https://user-images.githubusercontent.com/15329494/196716424-302884ca-d68c-4060-ba33-899ff6e29fa7.png)

CC @anasereijo 

Ref #319 