### PR TITLE
ExplorePage: simpify hiearchy and return filter

### DIFF
--- a/lib/store_app/explore/explore_header.dart
+++ b/lib/store_app/explore/explore_header.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:software/store_app/common/app_format.dart';
+import 'package:software/store_app/common/app_format_popup.dart';
+import 'package:software/store_app/common/packagekit/packagekit_filter_button.dart';
+import 'package:software/store_app/common/packagekit/packagekit_group_button.dart';
+import 'package:software/store_app/common/snap/snap_section_popup.dart';
+import 'package:software/store_app/explore/explore_model.dart';
+
+class ExploreHeader extends StatelessWidget {
+  const ExploreHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final model = context.watch<ExploreModel>();
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 20, left: 25, bottom: 20),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Wrap(
+          alignment: WrapAlignment.start,
+          crossAxisAlignment: WrapCrossAlignment.start,
+          runAlignment: WrapAlignment.start,
+          spacing: 10,
+          children: [
+            AppFormatPopup(
+              appFormat: model.appFormat,
+              onSelected: model.setAppFormat,
+            ),
+            if (model.appFormat == AppFormat.snap)
+              SnapSectionPopup(
+                value: model.selectedSection,
+                onSelected: (v) => model.selectedSection = v,
+              ),
+            if (model.appFormat == AppFormat.packageKit)
+              PackageKitFilterButton(
+                onTap: model.handleFilter,
+                filters: model.packageKitFilters,
+              ),
+            if (model.appFormat == AppFormat.packageKit)
+              PackageKitGroupButton(
+                onSelected: (v) => model.setPackageKitGroup(v),
+                value: model.packageKitGroup,
+              )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/store_app/explore/explore_model.dart
+++ b/lib/store_app/explore/explore_model.dart
@@ -58,14 +58,6 @@ class ExploreModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  int _appResulAmount = 10;
-  int get appResultAmount => _appResulAmount;
-  set appResultAmount(int value) {
-    if (value == _appResulAmount) return;
-    _appResulAmount = value;
-    notifyListeners();
-  }
-
   Snap? _selectedSnap;
   Snap? get selectedSnap => _selectedSnap;
   set selectedSnap(Snap? snap) {
@@ -123,9 +115,7 @@ class ExploreModel extends SafeChangeNotifier {
   SnapSection get selectedSection => _selectedSection;
   set selectedSection(SnapSection value) {
     if (value == _selectedSection) return;
-    _appResulAmount = 10;
     _selectedSection = value;
-    // loadSection(value);
     notifyListeners();
   }
 

--- a/lib/store_app/explore/explore_page.dart
+++ b/lib/store_app/explore/explore_page.dart
@@ -21,6 +21,7 @@ import 'package:software/l10n/l10n.dart';
 import 'package:software/services/package_service.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:software/store_app/common/constants.dart';
+import 'package:software/store_app/explore/explore_header.dart';
 import 'package:software/store_app/explore/offline_page.dart';
 import 'package:software/store_app/common/packagekit/package_page.dart';
 import 'package:software/store_app/common/snap/snap_page.dart';
@@ -86,16 +87,23 @@ class _ExplorePageState extends State<ExplorePage> {
             appBar: AppBar(
               flexibleSpace: const SearchField(),
             ),
-            body: model.showErrorPage
-                ? _ErrorPage(errorMessage: model.errorMessage)
-                : model.showSearchPage
-                    ? const SearchPage()
-                    : model.showStartPage
-                        ? StartPage(screenSize: screenSize)
-                        : SectionBannerGrid(
-                            initialAmount: (screenArea ~/ bannerArea) + 5,
-                            snapSection: model.selectedSection,
-                          ),
+            body: Column(
+              children: [
+                const ExploreHeader(),
+                Expanded(
+                  child: model.showErrorPage
+                      ? _ErrorPage(errorMessage: model.errorMessage)
+                      : model.showSearchPage
+                          ? const SearchPage()
+                          : model.showStartPage
+                              ? StartPage(screenSize: screenSize)
+                              : SectionBannerGrid(
+                                  initialAmount: (screenArea ~/ bannerArea) + 5,
+                                  snapSection: model.selectedSection,
+                                ),
+                )
+              ],
+            ),
           ),
         ),
         if (model.selectedSnap != null && model.selectedPackage == null)

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -23,12 +23,8 @@ import 'package:software/l10n/l10n.dart';
 import 'package:software/snapx.dart';
 import 'package:software/store_app/common/animated_scroll_view_item.dart';
 import 'package:software/store_app/common/app_format.dart';
-import 'package:software/store_app/common/app_format_popup.dart';
 import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/packagekit/packagekit_filter_button.dart';
-import 'package:software/store_app/common/packagekit/packagekit_group_button.dart';
-import 'package:software/store_app/common/snap/snap_section_popup.dart';
 import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -40,47 +36,11 @@ class SearchPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<ExploreModel>();
 
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(top: 20, left: 25),
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: Wrap(
-              alignment: WrapAlignment.start,
-              crossAxisAlignment: WrapCrossAlignment.start,
-              runAlignment: WrapAlignment.start,
-              spacing: 10,
-              children: [
-                AppFormatPopup(
-                  appFormat: model.appFormat,
-                  onSelected: model.setAppFormat,
-                ),
-                if (model.appFormat == AppFormat.snap)
-                  SnapSectionPopup(
-                    value: model.selectedSection,
-                    onSelected: (v) => model.selectedSection = v,
-                  ),
-                if (model.appFormat == AppFormat.packageKit)
-                  PackageKitFilterButton(
-                    onTap: model.handleFilter,
-                    filters: model.packageKitFilters,
-                  ),
-                if (model.appFormat == AppFormat.packageKit)
-                  PackageKitGroupButton(
-                    onSelected: (v) => model.setPackageKitGroup(v),
-                    value: model.packageKitGroup,
-                  )
-              ],
-            ),
-          ),
-        ),
-        if (model.appFormat == AppFormat.snap)
-          const Expanded(child: _SnapSearchPage())
-        else if (model.appFormat == AppFormat.packageKit)
-          const Expanded(child: _PackageKitSearchPage())
-      ],
-    );
+    if (model.appFormat == AppFormat.snap) {
+      return const _SnapSearchPage();
+    } else {
+      return const _PackageKitSearchPage();
+    }
   }
 }
 
@@ -92,46 +52,42 @@ class _SnapSearchPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<ExploreModel>();
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 20),
-      child: FutureBuilder<List<Snap>>(
-        future: model.findSnapsByQuery(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const _WaitPage(message: '');
-          }
+    return FutureBuilder<List<Snap>>(
+      future: model.findSnapsByQuery(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const _WaitPage(message: '');
+        }
 
-          return snapshot.hasData && snapshot.data!.isNotEmpty
-              ? GridView.builder(
-                  controller: ScrollController(),
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  gridDelegate: kGridDelegate,
-                  shrinkWrap: true,
-                  itemCount: snapshot.data!.length,
-                  itemBuilder: (context, index) {
-                    final snap = snapshot.data![index];
-                    return AnimatedScrollViewItem(
-                      child: YaruBanner(
-                        title: Text(snap.name),
-                        subtitle: Text(
-                          snap.summary,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        icon: AppIcon(
-                          iconUrl: snap.iconUrl,
-                          fallBackIconData: YaruIcons.snapcraft,
-                          size: 50,
-                          fallBackIconSize: 30,
-                        ),
-                        iconPadding: const EdgeInsets.only(left: 10, right: 5),
-                        onTap: () => model.selectedSnap = snap,
+        return snapshot.hasData && snapshot.data!.isNotEmpty
+            ? GridView.builder(
+                padding: const EdgeInsets.only(bottom: 20, left: 20, right: 20),
+                gridDelegate: kGridDelegate,
+                shrinkWrap: true,
+                itemCount: snapshot.data!.length,
+                itemBuilder: (context, index) {
+                  final snap = snapshot.data![index];
+                  return AnimatedScrollViewItem(
+                    child: YaruBanner(
+                      title: Text(snap.name),
+                      subtitle: Text(
+                        snap.summary,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    );
-                  },
-                )
-              : _NoSearchResultPage(message: context.l10n.noSnapFound);
-        },
-      ),
+                      icon: AppIcon(
+                        iconUrl: snap.iconUrl,
+                        fallBackIconData: YaruIcons.snapcraft,
+                        size: 50,
+                        fallBackIconSize: 30,
+                      ),
+                      iconPadding: const EdgeInsets.only(left: 10, right: 5),
+                      onTap: () => model.selectedSnap = snap,
+                    ),
+                  );
+                },
+              )
+            : _NoSearchResultPage(message: context.l10n.noSnapFound);
+      },
     );
   }
 }
@@ -164,38 +120,34 @@ class _PackageKitSearchPageState extends State<_PackageKitSearchPage> {
       );
     }
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 20),
-      child: FutureBuilder<List<PackageKitPackageId>>(
-        future: model.findPackageKitPackageIds(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const _WaitPage(message: '');
-          }
-          return snapshot.hasData && snapshot.data!.isNotEmpty
-              ? GridView.builder(
-                  controller: ScrollController(),
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  gridDelegate: kGridDelegate,
-                  shrinkWrap: true,
-                  itemCount: snapshot.data!.length,
-                  itemBuilder: (context, index) {
-                    final id = snapshot.data![index];
-                    return YaruBanner(
-                      title: Text(id.name),
-                      subtitle: Text(id.version),
-                      icon: const AppIcon(
-                        iconUrl: null,
-                        fallBackIconData: YaruIcons.debian,
-                      ),
-                      iconPadding: const EdgeInsets.only(left: 10, right: 5),
-                      onTap: () => model.selectedPackage = id,
-                    );
-                  },
-                )
-              : _NoSearchResultPage(message: context.l10n.noPackageFound);
-        },
-      ),
+    return FutureBuilder<List<PackageKitPackageId>>(
+      future: model.findPackageKitPackageIds(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const _WaitPage(message: '');
+        }
+        return snapshot.hasData && snapshot.data!.isNotEmpty
+            ? GridView.builder(
+                padding: const EdgeInsets.only(bottom: 20, left: 20, right: 20),
+                gridDelegate: kGridDelegate,
+                shrinkWrap: true,
+                itemCount: snapshot.data!.length,
+                itemBuilder: (context, index) {
+                  final id = snapshot.data![index];
+                  return YaruBanner(
+                    title: Text(id.name),
+                    subtitle: Text(id.version),
+                    icon: const AppIcon(
+                      iconUrl: null,
+                      fallBackIconData: YaruIcons.debian,
+                    ),
+                    iconPadding: const EdgeInsets.only(left: 10, right: 5),
+                    onTap: () => model.selectedPackage = id,
+                  );
+                },
+              )
+            : _NoSearchResultPage(message: context.l10n.noPackageFound);
+      },
     );
   }
 }

--- a/lib/store_app/explore/section_banner_grid.dart
+++ b/lib/store_app/explore/section_banner_grid.dart
@@ -73,7 +73,8 @@ class _SectionBannerGridState extends State<SectionBannerGrid> {
 
     return GridView.builder(
       controller: _controller,
-      padding: widget.padding ?? const EdgeInsets.all(20),
+      padding: widget.padding ??
+          const EdgeInsets.only(bottom: 20, left: 20, right: 20),
       shrinkWrap: true,
       gridDelegate: kGridDelegate,
       itemCount: sections.take(_amount).length,

--- a/lib/store_app/explore/start_page.dart
+++ b/lib/store_app/explore/start_page.dart
@@ -51,7 +51,7 @@ class _StartPageState extends State<StartPage> {
     }
 
     return GridView.builder(
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.only(bottom: 20, left: 20, right: 20),
       shrinkWrap: true,
       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
         mainAxisExtent: 200,


### PR DESCRIPTION
- return the filterbar for all explore page states
- do not insert new scrollcontroller every time for the search pages
- align padding to match on all explore sub pages

![grafik](https://user-images.githubusercontent.com/15329494/197419711-3a954333-eb6e-4665-917f-e80f594f8765.png)
