### PR TITLE
PackageService and Updates model last values

### DIFF
--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -107,17 +107,21 @@ class PackageService {
     lastRequireRestart = value;
   }
 
+  int? lastUpdatesPercentage;
   final _updatesPercentageController = StreamController<int?>.broadcast();
   Stream<int?> get updatesPercentage => _updatesPercentageController.stream;
   void setUpdatePercentage(int? value) {
     _updatesPercentageController.add(value);
+    lastUpdatesPercentage = value;
   }
 
+  PackageKitPackageId? lastProcessedId;
   final _processedIdController =
       StreamController<PackageKitPackageId?>.broadcast();
   Stream<PackageKitPackageId?> get processedId => _processedIdController.stream;
   void setProcessedId(PackageKitPackageId? value) {
     _processedIdController.add(value);
+    lastProcessedId = value;
   }
 
   final _errorMessageController = StreamController<String>.broadcast();
@@ -140,10 +144,12 @@ class PackageService {
     lastUpdatesState = value;
   }
 
+  PackageKitInfo? lastInfo;
   final _infoController = StreamController<PackageKitInfo?>.broadcast();
   Stream<PackageKitInfo?> get info => _infoController.stream;
   void setInfo(PackageKitInfo? value) {
     _infoController.add(value);
+    lastInfo = value;
   }
 
   final _statusController = StreamController<PackageKitStatus?>.broadcast();

--- a/lib/store_app/updates/updates_model.dart
+++ b/lib/store_app/updates/updates_model.dart
@@ -47,8 +47,14 @@ class UpdatesModel extends SafeChangeNotifier {
         _manualRepoName = '';
 
   void init() async {
+    // Init the model with the last values
     _updatesState = _service.lastUpdatesState;
+    _processedId = _service.lastProcessedId;
+    _info = _service.lastInfo;
+    _percentage = _service.lastUpdatesPercentage;
     _requireRestart = _service.lastRequireRestart ?? PackageKitRestart.none;
+
+    // Setup all stream subscriptions
     _updatesStateSub = _service.updatesState.listen((event) {
       updatesState = event;
     });


### PR DESCRIPTION
Like lastUpdatesState we need all values relevant for the updates page to be initialized, no matter if a value is put into the stream or not.