### PR TITLE
Do not track the currently displayed app/snap in the models (ExploreModel, MyAppsModel).

### DIFF
--- a/lib/store_app/common/app_page/app_page.dart
+++ b/lib/store_app/common/app_page/app_page.dart
@@ -32,7 +32,6 @@ class AppPage extends StatefulWidget {
   const AppPage({
     super.key,
     required this.appData,
-    required this.onPop,
     required this.icon,
     required this.permissionContainer,
     required this.controls,
@@ -41,7 +40,6 @@ class AppPage extends StatefulWidget {
   });
 
   final AppData appData;
-  final VoidCallback onPop;
   final Widget icon;
   final Widget? permissionContainer;
   final Widget controls;
@@ -184,7 +182,7 @@ class _AppPageState extends State<AppPage> {
       appBar: AppBar(
         title: Text(widget.appData.title),
         leading: _CustomBackButton(
-          onPressed: widget.onPop,
+          onPressed: () => Navigator.pop(context),
         ),
       ),
       body: isWindowWide

--- a/lib/store_app/common/packagekit/package_page.dart
+++ b/lib/store_app/common/packagekit/package_page.dart
@@ -34,29 +34,40 @@ class PackagePage extends StatefulWidget {
     required this.noUpdate,
     required this.id,
     required this.installedId,
-    required this.onPop,
   });
 
   final bool noUpdate;
   final PackageKitPackageId id;
   final PackageKitPackageId installedId;
-  final VoidCallback onPop;
 
   static Widget create({
     required BuildContext context,
     required PackageKitPackageId id,
     required PackageKitPackageId installedId,
     bool noUpdate = true,
-    required final VoidCallback onPop,
   }) {
     return ChangeNotifierProvider(
       create: (context) =>
           PackageModel(service: getService<PackageService>(), packageId: id),
       child: PackagePage(
-        onPop: onPop,
         noUpdate: noUpdate,
         id: id,
         installedId: installedId,
+      ),
+    );
+  }
+
+  static Future<void> push(BuildContext context, PackageKitPackageId id) {
+    return Navigator.push(
+      context,
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) {
+          return PackagePage.create(
+            context: context,
+            id: id,
+            installedId: id,
+          );
+        },
       ),
     );
   }
@@ -96,7 +107,6 @@ class _PackagePageState extends State<PackagePage> {
     );
     return AppPage(
       appData: appData,
-      onPop: widget.onPop,
       permissionContainer: const SizedBox(),
       icon: AppIcon(
         iconUrl: model.iconUrl,

--- a/lib/store_app/common/snap/snap_page.dart
+++ b/lib/store_app/common/snap/snap_page.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:snapd/snapd.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:software/store_app/common/app_data.dart';
@@ -29,14 +30,11 @@ import 'package:software/store_app/common/snap/snap_model.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 class SnapPage extends StatefulWidget {
-  const SnapPage({super.key, required this.onPop});
-
-  final VoidCallback onPop;
+  const SnapPage({super.key});
 
   static Widget create({
     required BuildContext context,
     required String huskSnapName,
-    required final VoidCallback onPop,
   }) =>
       ChangeNotifierProvider<SnapModel>(
         create: (_) => SnapModel(
@@ -44,8 +42,22 @@ class SnapPage extends StatefulWidget {
           getService<SnapService>(),
           huskSnapName: huskSnapName,
         ),
-        child: SnapPage(onPop: onPop),
+        child: const SnapPage(),
       );
+
+  static Future<void> push(BuildContext context, Snap snap) {
+    return Navigator.push(
+      context,
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) {
+          return SnapPage.create(
+            context: context,
+            huskSnapName: snap.name,
+          );
+        },
+      ),
+    );
+  }
 
   @override
   State<SnapPage> createState() => _SnapPageState();
@@ -84,7 +96,6 @@ class _SnapPageState extends State<SnapPage> {
 
     return AppPage(
       appData: appData,
-      onPop: widget.onPop,
       permissionContainer: model.showPermissions
           ? const BorderContainer(
               child: SnapConnectionsSettings(),

--- a/lib/store_app/explore/explore_model.dart
+++ b/lib/store_app/explore/explore_model.dart
@@ -58,22 +58,6 @@ class ExploreModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  Snap? _selectedSnap;
-  Snap? get selectedSnap => _selectedSnap;
-  set selectedSnap(Snap? snap) {
-    if (snap == _selectedSnap) return;
-    _selectedSnap = snap;
-    notifyListeners();
-  }
-
-  PackageKitPackageId? _selectedPackage;
-  PackageKitPackageId? get selectedPackage => _selectedPackage;
-  set selectedPackage(PackageKitPackageId? id) {
-    if (id == _selectedPackage) return;
-    _selectedPackage = id;
-    notifyListeners();
-  }
-
   ExploreModel(
     this._snapService,
     this._packageService,
@@ -170,11 +154,6 @@ class ExploreModel extends SafeChangeNotifier {
         ],
         filter: packageKitFilters,
       );
-
-  void clearSelection() {
-    selectedSnap = null;
-    selectedPackage = null;
-  }
 
   AppFormat _appFormat = AppFormat.snap;
   AppFormat get appFormat => _appFormat;

--- a/lib/store_app/explore/explore_page.dart
+++ b/lib/store_app/explore/explore_page.dart
@@ -23,8 +23,6 @@ import 'package:software/services/snap_service.dart';
 import 'package:software/store_app/common/constants.dart';
 import 'package:software/store_app/explore/explore_header.dart';
 import 'package:software/store_app/explore/offline_page.dart';
-import 'package:software/store_app/common/packagekit/package_page.dart';
-import 'package:software/store_app/common/snap/snap_page.dart';
 import 'package:software/store_app/common/snap/snap_section.dart';
 import 'package:software/store_app/explore/explore_model.dart';
 import 'package:software/store_app/explore/search_field.dart';
@@ -106,25 +104,6 @@ class _ExplorePageState extends State<ExplorePage> {
             ),
           ),
         ),
-        if (model.selectedSnap != null && model.selectedPackage == null)
-          MaterialPage(
-            key: ObjectKey(model.selectedSnap),
-            child: SnapPage.create(
-              context: context,
-              huskSnapName: model.selectedSnap!.name,
-              onPop: () => model.selectedSnap = null,
-            ),
-          ),
-        if (model.selectedPackage != null && model.selectedSnap == null)
-          MaterialPage(
-            key: ObjectKey(model.selectedPackage),
-            child: PackagePage.create(
-              context: context,
-              id: model.selectedPackage!,
-              installedId: model.selectedPackage!,
-              onPop: model.clearSelection,
-            ),
-          ),
       ],
       onPopPage: (route, result) => route.didPop(result),
     );

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -25,6 +25,8 @@ import 'package:software/store_app/common/animated_scroll_view_item.dart';
 import 'package:software/store_app/common/app_format.dart';
 import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
+import 'package:software/store_app/common/packagekit/package_page.dart';
+import 'package:software/store_app/common/snap/snap_page.dart';
 import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -88,7 +90,7 @@ class _SnapSearchPage extends StatelessWidget {
                         fallBackIconSize: 30,
                       ),
                       iconPadding: const EdgeInsets.only(left: 10, right: 5),
-                      onTap: () => model.selectedSnap = snap,
+                      onTap: () => SnapPage.push(context, snap),
                     ),
                   );
                 },
@@ -149,7 +151,7 @@ class _PackageKitSearchPageState extends State<_PackageKitSearchPage> {
                       fallBackIconData: YaruIcons.debian,
                     ),
                     iconPadding: const EdgeInsets.only(left: 10, right: 5),
-                    onTap: () => model.selectedPackage = id,
+                    onTap: () => PackagePage.push(context, id),
                   );
                 },
               )
@@ -281,10 +283,7 @@ class _CombinedSearchPage extends StatelessWidget {
                             ),
                             onPressed: e.value.packageId == null
                                 ? null
-                                : () {
-                                    model.selectedPackage == null;
-                                    model.selectedSnap = e.value.snap;
-                                  },
+                                : () => SnapPage.push(context, e.value.snap!),
                           ),
                         if (e.value.packageId != null)
                           Padding(
@@ -292,10 +291,10 @@ class _CombinedSearchPage extends StatelessWidget {
                             child: IconButton(
                               onPressed: e.value.snap == null
                                   ? null
-                                  : () {
-                                      model.selectedSnap = null;
-                                      model.selectedPackage = e.value.packageId;
-                                    },
+                                  : () => PackagePage.push(
+                                        context,
+                                        e.value.packageId!,
+                                      ),
                               icon: Icon(
                                 YaruIcons.debian,
                                 color: e.value.snap == null
@@ -317,12 +316,12 @@ class _CombinedSearchPage extends StatelessWidget {
                         : () {
                             if (e.value.snap == null &&
                                 e.value.packageId != null) {
-                              model.selectedPackage = e.value.packageId;
+                              PackagePage.push(context, e.value.packageId!);
                             }
 
                             if (e.value.snap != null &&
                                 e.value.packageId == null) {
-                              model.selectedSnap = e.value.snap;
+                              SnapPage.push(context, e.value.snap!);
                             }
                           },
                   );

--- a/lib/store_app/explore/section_banner_grid.dart
+++ b/lib/store_app/explore/section_banner_grid.dart
@@ -21,6 +21,7 @@ import 'package:software/snapx.dart';
 import 'package:software/store_app/common/animated_scroll_view_item.dart';
 import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
+import 'package:software/store_app/common/snap/snap_page.dart';
 import 'package:software/store_app/common/snap/snap_section.dart';
 import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -93,7 +94,7 @@ class _SectionBannerGridState extends State<SectionBannerGrid> {
               iconUrl: snap.iconUrl,
             ),
           ),
-          onTap: () => model.selectedSnap = snap,
+          onTap: () => SnapPage.push(context, snap),
         );
 
         if (widget.animateBanners) {

--- a/lib/store_app/explore/start_page.dart
+++ b/lib/store_app/explore/start_page.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/l10n/l10n.dart';
+import 'package:software/store_app/common/snap/snap_page.dart';
 import 'package:software/store_app/common/snap/snap_section.dart';
 import 'package:software/store_app/explore/color_banner.dart';
 import 'package:software/store_app/explore/explore_model.dart';
@@ -71,7 +72,7 @@ class _StartPageState extends State<StartPage> {
           sectionName: section == SnapSection.all
               ? SnapSection.featured.localize(context.l10n)
               : section.localize(context.l10n),
-          onTap: () => model.selectedSnap = snap,
+          onTap: () => SnapPage.push(context, snap),
         );
       },
     );

--- a/lib/store_app/my_apps/my_apps_model.dart
+++ b/lib/store_app/my_apps/my_apps_model.dart
@@ -40,22 +40,6 @@ class MyAppsModel extends SafeChangeNotifier {
   final List<Snap> _localSnaps;
   List<Snap> get localSnaps => _localSnaps;
 
-  Snap? _selectedSnap;
-  Snap? get selectedSnap => _selectedSnap;
-  set selectedSnap(Snap? snap) {
-    if (snap == _selectedSnap) return;
-    _selectedSnap = snap;
-    notifyListeners();
-  }
-
-  PackageKitPackageId? _selectedPackage;
-  PackageKitPackageId? get selectedPackage => _selectedPackage;
-  set selectedPackage(PackageKitPackageId? id) {
-    if (id == _selectedPackage) return;
-    _selectedPackage = id;
-    notifyListeners();
-  }
-
   Future<void> init() async {
     await _loadLocalSnaps();
     _snapChangesSub = _snapService.snapChangesInserted.listen((_) {
@@ -86,11 +70,6 @@ class MyAppsModel extends SafeChangeNotifier {
     snaps.sort((a, b) => a.name.compareTo(b.name));
     _localSnaps.clear();
     _localSnaps.addAll(snaps);
-  }
-
-  void clearSelection() {
-    selectedSnap = null;
-    selectedPackage = null;
   }
 
   String? _searchQuery;

--- a/lib/store_app/my_apps/my_apps_page.dart
+++ b/lib/store_app/my_apps/my_apps_page.dart
@@ -21,8 +21,6 @@ import 'package:software/l10n/l10n.dart';
 import 'package:software/services/package_service.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:software/store_app/common/app_format.dart';
-import 'package:software/store_app/common/packagekit/package_page.dart';
-import 'package:software/store_app/common/snap/snap_page.dart';
 import 'package:software/store_app/my_apps/my_apps_header.dart';
 import 'package:software/store_app/my_apps/my_apps_model.dart';
 import 'package:software/store_app/my_apps/my_apps_search_field.dart';
@@ -90,25 +88,6 @@ class MyAppsPage extends StatelessWidget {
             body: page,
           ),
         ),
-        if (model.selectedSnap != null && model.selectedPackage == null)
-          MaterialPage(
-            key: ObjectKey(model.selectedSnap),
-            child: SnapPage.create(
-              context: context,
-              huskSnapName: model.selectedSnap!.name,
-              onPop: model.clearSelection,
-            ),
-          ),
-        if (model.selectedPackage != null && model.selectedSnap == null)
-          MaterialPage(
-            key: ObjectKey(model.selectedSnap),
-            child: PackagePage.create(
-              context: context,
-              id: model.selectedPackage!,
-              installedId: model.selectedPackage!,
-              onPop: model.clearSelection,
-            ),
-          ),
       ],
       onPopPage: (route, result) => route.didPop(result),
     );

--- a/lib/store_app/my_apps/my_packages_page.dart
+++ b/lib/store_app/my_apps/my_packages_page.dart
@@ -20,6 +20,7 @@ import 'package:provider/provider.dart';
 import 'package:software/store_app/common/animated_scroll_view_item.dart';
 import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
+import 'package:software/store_app/common/packagekit/package_page.dart';
 import 'package:software/store_app/my_apps/my_apps_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -69,7 +70,7 @@ class _MyPackagesPageState extends State<MyPackagesPage> {
                 child: YaruBanner(
                   title: Text(package.name),
                   subtitle: Text(package.version),
-                  onTap: () => model.selectedPackage = package,
+                  onTap: () => PackagePage.push(context, package),
                   iconPadding: const EdgeInsets.only(left: 10, right: 5),
                   icon: const AppIcon(
                     iconUrl: null,

--- a/lib/store_app/my_apps/my_snaps_page.dart
+++ b/lib/store_app/my_apps/my_snaps_page.dart
@@ -49,23 +49,7 @@ class _MySnapsPageState extends State<MySnapsPage> {
               (s) => s.name.startsWith(model.searchQuery!),
             )
             .toList();
-    return Navigator(
-      pages: [
-        MaterialPage(
-          child: _MySnapsGrid(snaps: snaps),
-        ),
-        if (model.selectedSnap != null)
-          MaterialPage(
-            key: ObjectKey(model.selectedSnap),
-            child: SnapPage.create(
-              context: context,
-              huskSnapName: model.selectedSnap!.name,
-              onPop: () => model.selectedSnap = null,
-            ),
-          )
-      ],
-      onPopPage: (route, result) => route.didPop(result),
-    );
+    return _MySnapsGrid(snaps: snaps);
   }
 }
 
@@ -126,7 +110,7 @@ class __MySnapsGridState extends State<_MySnapsGrid> {
                 iconUrl: snap.iconUrl,
               ),
             ),
-            onTap: () => model.selectedSnap = snap,
+            onTap: () => SnapPage.push(context, snap),
           ),
         );
       },


### PR DESCRIPTION
This ensures that the corresponding pages are not rebuilt when popping a details page (#444).