### PR TITLE
AppReviews: use column instead of listview

### DIFF
--- a/lib/store_app/common/app_page/app_reviews.dart
+++ b/lib/store_app/common/app_page/app_reviews.dart
@@ -24,8 +24,7 @@ class AppReviews extends StatelessWidget {
           context.l10n.reviewsAndRatings,
           style: Theme.of(context).textTheme.headline6,
         ),
-        child: ListView(
-          shrinkWrap: true,
+        child: Column(
           children: [
             const SizedBox(
               height: kYaruPagePadding,


### PR DESCRIPTION
nested scrollviews do not work with wayland and trackpads