### PR TITLE
Regression: app pages should not hide navigation

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -96,5 +96,6 @@
   "yourReview": "Ihre Rezension",
   "send": "Send",
   "unknown": "Unbekannt",
-  "reviewSent": "Rezension versendet"
+  "reviewSent": "Rezension versendet",
+  "multiAppFormatsFound": "Wir konnten verschiedene Formate für diese Anwendung finden."
 } 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -96,5 +96,6 @@
   "yourReview": "Your review",
   "send": "Send",
   "unknown": "Unknown",
-  "reviewSent": "Review sent"
+  "reviewSent": "Review sent",
+  "multiAppFormatsFound": "We've found multiple formats for this application."
 } 

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -304,9 +304,10 @@ class _CombinedSearchPage extends StatelessWidget {
                         const EdgeInsets.only(left: 10, right: 5, bottom: 30),
                     onTap: e.value.snap != null && e.value.packageId != null
                         ? () => showDialog(
+                              useRootNavigator: false,
                               context: context,
                               builder: (context) => _AppFormatSelectDialog(
-                                title: e.value.snap!.title!,
+                                title: e.value.snap!.name,
                                 onPackageSelect: () => PackagePage.push(
                                   context,
                                   e.value.packageId!,
@@ -385,24 +386,48 @@ class _AppFormatSelectDialog extends StatelessWidget {
     return AlertDialog(
       title: YaruTitleBar(title: Text(title)),
       titlePadding: EdgeInsets.zero,
-      actionsPadding: EdgeInsets.zero,
+      actionsPadding: const EdgeInsets.all(10),
       actionsAlignment: MainAxisAlignment.spaceEvenly,
+      content: Text(context.l10n.multiAppFormatsFound),
       actions: [
         Row(
           children: [
             Expanded(
               child: TextButton(
                 onPressed: onPackageSelect,
-                child: Text(
-                  AppFormat.packageKit.localize(context.l10n),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(YaruIcons.debian, size: 16),
+                    const SizedBox(
+                      width: 5,
+                    ),
+                    Text(
+                      AppFormat.packageKit.localize(context.l10n),
+                    ),
+                  ],
                 ),
               ),
             ),
             Expanded(
               child: TextButton(
                 onPressed: onSnapSelect,
-                child: Text(
-                  AppFormat.snap.localize(context.l10n),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      YaruIcons.snapcraft,
+                      size: 16,
+                    ),
+                    const SizedBox(
+                      width: 5,
+                    ),
+                    Text(
+                      AppFormat.snap.localize(context.l10n),
+                    ),
+                  ],
                 ),
               ),
             )


### PR DESCRIPTION
Fixes #474

Plus updates to the dialog:

- more space for buttons
- add a message what's happening


https://user-images.githubusercontent.com/15329494/199501811-3143df67-6cf7-4afb-910f-ad0147d0d8ea.mp4

