### PR TITLE
Udapte yaru_widgets and revert FittedBox

### DIFF
--- a/lib/store_app/common/app_page/app_header.dart
+++ b/lib/store_app/common/app_page/app_header.dart
@@ -57,12 +57,10 @@ class BannerAppHeader extends StatelessWidget {
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    FittedBox(
-                      child: Text(
-                        appData.title,
-                        style: Theme.of(context).textTheme.headline3,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                    Text(
+                      appData.title,
+                      style: Theme.of(context).textTheme.headline3,
+                      overflow: TextOverflow.ellipsis,
                     ),
                     AppWebsite(
                       website: appData.website,
@@ -110,15 +108,13 @@ class PageAppHeader extends StatelessWidget {
               height: iconSize,
               child: icon,
             ),
-            FittedBox(
-              child: Padding(
-                padding: const EdgeInsets.all(kYaruPagePadding),
-                child: Text(
-                  appData.title,
-                  style: Theme.of(context).textTheme.headline3,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                ),
+            Padding(
+              padding: const EdgeInsets.all(kYaruPagePadding),
+              child: Text(
+                appData.title,
+                style: Theme.of(context).textTheme.headline3,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
               ),
             ),
             AppWebsite(

--- a/lib/store_app/common/app_page/app_page.dart
+++ b/lib/store_app/common/app_page/app_page.dart
@@ -58,7 +58,6 @@ class _AppPageState extends State<AppPage> {
   void initState() {
     super.initState();
     controller = YaruCarouselController(
-      pagesLength: widget.appData.screenShotUrls.length,
       viewportFraction: 1,
     );
   }
@@ -229,7 +228,6 @@ class _CarouselDialogState extends State<_CarouselDialog> {
   void initState() {
     super.initState();
     controller = YaruCarouselController(
-      pagesLength: widget.appData.screenShotUrls.length,
       initialPage: widget.initialIndex,
       viewportFraction: 0.8,
     );

--- a/lib/store_app/common/snap/snap_connections_settings.dart
+++ b/lib/store_app/common/snap/snap_connections_settings.dart
@@ -52,7 +52,7 @@ class SnapConnectionsSettings extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(plugEntry.key.interface ?? ''),
-                    Switch(
+                    YaruSwitch(
                       value: plugEntry.value,
                       onChanged: model.snapChangeInProgress
                           ? null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,10 +44,7 @@ dependencies:
   yaru: ^0.4.1
   yaru_colors: ^0.1.0
   yaru_icons: ^0.2.4
-  yaru_widgets:
-    git:
-      url: https://github.com/ubuntu/yaru_widgets.dart
-      ref: aa90a9a9021d4ead0791dda3122d7ca352e4a58b
+  yaru_widgets: ^2.0.0-beta-1
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
- update yaru_widgets to 2.0.0-beta-1
- revert the fittedbox change to AppHeader for now
- exchange Switch with YaruSwitch
![grafik](https://user-images.githubusercontent.com/15329494/200425323-6f9915cb-c005-4cb5-a77e-4b1ca6637f17.png)

- adapt YaruCarouselController to yaru_widgets