### PR TITLE
Improve PackageService updateAll

### DIFF
--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -347,6 +347,8 @@ class PackageService {
           NotificationHint.urgency(NotificationUrgency.normal)
         ],
       );
+    } else {
+      setUpdatesState(UpdatesState.readyToUpdate);
     }
   }
 

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -318,6 +318,7 @@ class PackageService {
       } else {
         if (event.code == PackageKitError.notAuthorized) {
           canceled = true;
+          setUpdatesState(UpdatesState.readyToUpdate);
         }
         if (isUpdateErrorToReport(event.code)) {
           final error = '${event.code}: ${event.details}';

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -326,6 +326,8 @@ class PackageService {
     await updatePackagesTransaction.updatePackages(selectedUpdates);
     if (!canceled) {
       setUpdatesState(UpdatesState.updating);
+    } else {
+      setUpdatesState(UpdatesState.readyToUpdate);
     }
     await completer.future.whenComplete(subscription.cancel);
     if (!canceled) {

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -293,7 +293,6 @@ class PackageService {
     if (selectedUpdates.isEmpty) return;
     final updatePackagesTransaction = await _client.createTransaction();
     final completer = Completer();
-    setUpdatesState(UpdatesState.updating);
     final subscription = updatePackagesTransaction.events.listen((event) {
       if (event is PackageKitRequireRestartEvent) {
         setRequireRestart(event.type);
@@ -325,6 +324,7 @@ class PackageService {
       }
     });
     await updatePackagesTransaction.updatePackages(selectedUpdates);
+    setUpdatesState(UpdatesState.updating);
     await completer.future.whenComplete(subscription.cancel);
     if (!canceled) {
       _updates.clear();
@@ -347,8 +347,6 @@ class PackageService {
           NotificationHint.urgency(NotificationUrgency.normal)
         ],
       );
-    } else {
-      setUpdatesState(UpdatesState.readyToUpdate);
     }
   }
 

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -235,7 +235,10 @@ class PackageService {
       if (event is PackageKitRepositoryDetailEvent) {
         // print(event.description);
       } else if (event is PackageKitErrorCodeEvent) {
-        setErrorMessage('${event.code}: ${event.details}');
+        if (isValidRefreshError(event.code)) {
+          final error = '${event.code}: ${event.details}';
+          setErrorMessage(error);
+        }
       } else if (event is PackageKitFinishedEvent) {
         completer.complete();
       }
@@ -258,7 +261,10 @@ class PackageService {
       } else if (event is PackageKitItemProgressEvent) {
         setUpdatePercentage(event.percentage);
       } else if (event is PackageKitErrorCodeEvent) {
-        setErrorMessage('${event.code}: ${event.details}');
+        if (isValidRefreshError(event.code)) {
+          final error = '${event.code}: ${event.details}';
+          setErrorMessage(error);
+        }
       } else if (event is PackageKitFinishedEvent) {
         completer.complete();
       }
@@ -305,9 +311,11 @@ class PackageService {
         setTerminalOutput(event.packageId.toString());
         setTerminalOutput(event.status.toString());
       } else if (event is PackageKitErrorCodeEvent) {
-        final error = '${event.code}: ${event.details}';
-        setErrorMessage(error);
-        setTerminalOutput(error);
+        if (isValidUpdateError(event.code)) {
+          final error = '${event.code}: ${event.details}';
+          setErrorMessage(error);
+          setTerminalOutput(error);
+        }
       } else if (event is PackageKitFinishedEvent) {
         completer.complete();
       }
@@ -628,21 +636,16 @@ class PackageService {
     return completer.future.whenComplete(subscription.cancel);
   }
 
-  void reboot() {
-    Process.start(
-      'reboot',
-      [],
-      mode: ProcessStartMode.detached,
-    );
+  bool isValidRefreshError(PackageKitError code) {
+    return !{
+      PackageKitError.failedConfigParsing,
+    }.contains(code);
   }
 
-  // gnome-session-quit
-  logout() {
-    Process.start(
-      'gnome-session-quit',
-      [],
-      mode: ProcessStartMode.detached,
-    );
+  bool isValidUpdateError(PackageKitError code) {
+    return !{
+      PackageKitError.notAuthorized,
+    }.contains(code);
   }
 
   exitApp() => exit(0);

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -324,7 +324,9 @@ class PackageService {
       }
     });
     await updatePackagesTransaction.updatePackages(selectedUpdates);
-    setUpdatesState(UpdatesState.updating);
+    if (!canceled) {
+      setUpdatesState(UpdatesState.updating);
+    }
     await completer.future.whenComplete(subscription.cancel);
     if (!canceled) {
       _updates.clear();

--- a/lib/store_app/updates/updates_model.dart
+++ b/lib/store_app/updates/updates_model.dart
@@ -239,7 +239,7 @@ class UpdatesModel extends SafeChangeNotifier {
 
   void reboot() => _session.reboot();
 
-  void logout() => _service.logout();
+  void logout() => _session.logout();
 
   void exitApp() => _service.exitApp();
 


### PR DESCRIPTION
- clean up event-type checking control block to only if or elf if blocks
- only set update state to updating in progress events
- check if the transaction has been canceled
- only clean up updates and stream controllers if the process has not been cancelled
- create sets of events that should be ignored to not report every error to the model and thus the view
- only use ubuntu session commands to control logout/reboot

Ref #503
Ref #488