### PR TITLE
Remove extra padding between Description and Review containers

### DIFF
--- a/lib/store_app/common/packagekit/package_page.dart
+++ b/lib/store_app/common/packagekit/package_page.dart
@@ -120,7 +120,7 @@ class _PackagePageState extends State<PackagePage> {
     );
     return AppPage(
       appData: appData,
-      permissionContainer: const SizedBox(),
+      permissionContainer: null,
       icon: AppIcon(
         iconUrl: model.iconUrl,
         fallBackIconData: YaruIcons.debian,


### PR DESCRIPTION
Makes permissionContainer null to make it work with the if statement clause. Removes additional padding.

<details>

<summary>Before:</summary>

![Screenshot from 2022-11-14 21-50-20](https://user-images.githubusercontent.com/73116038/201775803-ff41c6e7-b7c9-4f76-8480-bd604e6a59d7.png)

</details>

<details>

<summary>After:</summary>

![Screenshot from 2022-11-14 21-49-45](https://user-images.githubusercontent.com/73116038/201775822-d3133322-cc60-4e62-a73e-4cd76e6c31ac.png)

</details>

Fixes #512 