### PR TITLE
Require specific 0.2.7 version of yaru_icons

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   xterm: ^3.3.0
   yaru: ^0.4.1
   yaru_colors: ^0.1.0
-  yaru_icons: ^0.2.4
+  yaru_icons: ^0.2.7
   yaru_widgets: ^2.0.0-beta-1
 
 dev_dependencies:


### PR DESCRIPTION
Just require `yaru_icons: 0.2.7` to get the patch.
The visual diff is very very soft, so sorry but no screenshot :D

Fixes #528