### PR TITLE
Fixes some small padding miss-alignment with the HeaderBar and the PannedPageLayout

### DIFF
--- a/lib/store_app/common/app_icon.dart
+++ b/lib/store_app/common/app_icon.dart
@@ -25,20 +25,28 @@ class AppIcon extends StatelessWidget {
     super.key,
     required this.iconUrl,
     this.size = 45,
+    this.borderColor,
+    this.color,
   });
 
   final String? iconUrl;
   final double size;
+  final Color? borderColor;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
     final fallBackIcon = BorderContainer(
-      clipBehavior: Clip.hardEdge,
+      borderColor: color,
       containerPadding: EdgeInsets.zero,
       borderRadius: 200,
       width: size,
       height: size,
-      child: _FallBackIcon(size: size),
+      child: _FallBackIcon(
+        size: size,
+        borderColor: borderColor,
+        color: color,
+      ),
     );
 
     return iconUrl == null || iconUrl!.isEmpty
@@ -63,27 +71,37 @@ class _FallBackIcon extends StatelessWidget {
   const _FallBackIcon({
     Key? key,
     required this.size,
+    this.borderColor,
+    this.color,
   }) : super(key: key);
 
   final double size;
+  final Color? borderColor;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final light = theme.brightness == Brightness.light;
     final border = BorderSide(
-      color: light ? Colors.white : theme.dividerColor,
+      color: borderColor ?? (light ? Colors.white : theme.dividerColor),
       width: light ? 0.5 : 0.3,
     );
-    final shadeMax = light
-        ? theme.dividerColor.withOpacity(0.1)
-        : theme.colorScheme.onSurface.withOpacity(0.03);
-    final shadeMid = light
-        ? theme.dividerColor.withOpacity(0.05)
-        : theme.colorScheme.onSurface.withOpacity(0.015);
-    final shadeMin = light
-        ? theme.dividerColor.withOpacity(0.005)
-        : theme.colorScheme.onSurface.withOpacity(0.005);
+    final shadeMax = color != null
+        ? color!.withOpacity(0.1)
+        : light
+            ? theme.dividerColor.withOpacity(0.1)
+            : theme.colorScheme.onSurface.withOpacity(0.03);
+    final shadeMid = color != null
+        ? color!.withOpacity(0.05)
+        : light
+            ? theme.dividerColor.withOpacity(0.05)
+            : theme.colorScheme.onSurface.withOpacity(0.015);
+    final shadeMin = color != null
+        ? color!.withOpacity(0.005)
+        : light
+            ? theme.dividerColor.withOpacity(0.005)
+            : theme.colorScheme.onSurface.withOpacity(0.005);
     return ClipOval(
       child: FittedBox(
         fit: BoxFit.none,

--- a/lib/store_app/common/app_icon.dart
+++ b/lib/store_app/common/app_icon.dart
@@ -15,38 +15,30 @@
  *
  */
 
-import 'package:flutter/widgets.dart';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
 import 'package:software/store_app/common/border_container.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 class AppIcon extends StatelessWidget {
   const AppIcon({
     super.key,
     required this.iconUrl,
-    this.fallBackIconData = YaruIcons.snapcraft,
     this.size = 45,
-    this.fallBackIconSize = 20,
-    this.fallBackIconColor,
   });
 
   final String? iconUrl;
-  final IconData fallBackIconData;
   final double size;
-  final double fallBackIconSize;
-  final Color? fallBackIconColor;
 
   @override
   Widget build(BuildContext context) {
     final fallBackIcon = BorderContainer(
+      clipBehavior: Clip.hardEdge,
       containerPadding: EdgeInsets.zero,
       borderRadius: 200,
       width: size,
       height: size,
-      child: Icon(
-        fallBackIconData,
-        size: fallBackIconSize,
-        color: fallBackIconColor,
-      ),
+      child: _FallBackIcon(size: size),
     );
 
     return iconUrl == null || iconUrl!.isEmpty
@@ -64,5 +56,85 @@ class AppIcon extends StatelessWidget {
               errorBuilder: (context, error, stackTrace) => fallBackIcon,
             ),
           );
+  }
+}
+
+class _FallBackIcon extends StatelessWidget {
+  const _FallBackIcon({
+    Key? key,
+    required this.size,
+  }) : super(key: key);
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final light = theme.brightness == Brightness.light;
+    final border = BorderSide(
+      color: light ? Colors.white : theme.dividerColor,
+      width: light ? 0.5 : 0.3,
+    );
+    final shadeMax = light
+        ? theme.dividerColor.withOpacity(0.1)
+        : theme.colorScheme.onSurface.withOpacity(0.03);
+    final shadeMid = light
+        ? theme.dividerColor.withOpacity(0.05)
+        : theme.colorScheme.onSurface.withOpacity(0.015);
+    final shadeMin = light
+        ? theme.dividerColor.withOpacity(0.005)
+        : theme.colorScheme.onSurface.withOpacity(0.005);
+    return ClipOval(
+      child: FittedBox(
+        fit: BoxFit.none,
+        child: Transform.rotate(
+          angle: -pi / 4,
+          child: Row(
+            children: [
+              Column(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(size),
+                    decoration: BoxDecoration(
+                      border: Border(
+                        right: border,
+                      ),
+                      color: shadeMid,
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.all(size),
+                    decoration: BoxDecoration(
+                      color: shadeMax,
+                      border: Border(
+                        top: border,
+                        right: border,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(size * 1.2),
+                    decoration: BoxDecoration(
+                      color: shadeMin,
+                      border: Border(
+                        bottom: border,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.all(size * 1.2),
+                    decoration: BoxDecoration(color: shadeMid),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/store_app/common/app_page/app_loading_page.dart
+++ b/lib/store_app/common/app_page/app_loading_page.dart
@@ -138,6 +138,12 @@ class AppLoadingPage extends StatelessWidget {
       ],
     );
 
+    final body = isWindowWide
+        ? wideWindowLayout
+        : isWindowNormalSized
+            ? normalWindowLayout
+            : narrowWindowLayout;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text(''),
@@ -146,11 +152,12 @@ class AppLoadingPage extends StatelessWidget {
           onPressed: () => Navigator.pop(context),
         ),
       ),
-      body: isWindowWide
-          ? wideWindowLayout
-          : isWindowNormalSized
-              ? normalWindowLayout
-              : narrowWindowLayout,
+      body: GestureDetector(
+        onHorizontalDragEnd: (details) {
+          Navigator.of(context).pop();
+        },
+        child: body,
+      ),
     );
   }
 }

--- a/lib/store_app/common/app_page/app_page.dart
+++ b/lib/store_app/common/app_page/app_page.dart
@@ -186,6 +186,12 @@ class _AppPageState extends State<AppPage> {
       ],
     );
 
+    final body = isWindowWide
+        ? wideWindowLayout
+        : isWindowNormalSized
+            ? normalWindowLayout
+            : narrowWindowLayout;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.appData.title),
@@ -194,11 +200,12 @@ class _AppPageState extends State<AppPage> {
           onPressed: () => Navigator.pop(context),
         ),
       ),
-      body: isWindowWide
-          ? wideWindowLayout
-          : isWindowNormalSized
-              ? normalWindowLayout
-              : narrowWindowLayout,
+      body: GestureDetector(
+        onHorizontalDragEnd: (details) {
+          Navigator.of(context).pop();
+        },
+        child: body,
+      ),
     );
   }
 }

--- a/lib/store_app/common/app_page/page_layouts.dart
+++ b/lib/store_app/common/app_page/page_layouts.dart
@@ -26,12 +26,7 @@ class PanedPageLayout extends StatelessWidget {
 
     return Center(
       child: Padding(
-        padding: EdgeInsets.only(
-          top: kPagePadding,
-          bottom: kPagePadding,
-          left: kPagePadding,
-          right: hPadding,
-        ),
+        padding: const EdgeInsets.all(kPagePadding),
         child: SizedBox(
           height: height - appBarHeight,
           child: Row(
@@ -46,6 +41,7 @@ class PanedPageLayout extends StatelessWidget {
               Expanded(
                 child: ListView(
                   shrinkWrap: false,
+                  clipBehavior: Clip.none,
                   children: [
                     for (final child in rightChildren)
                       Padding(

--- a/lib/store_app/common/app_page/page_layouts.dart
+++ b/lib/store_app/common/app_page/page_layouts.dart
@@ -41,7 +41,6 @@ class PanedPageLayout extends StatelessWidget {
               Expanded(
                 child: ListView(
                   shrinkWrap: false,
-                  clipBehavior: Clip.none,
                   children: [
                     for (final child in rightChildren)
                       Padding(

--- a/lib/store_app/common/app_page/page_layouts.dart
+++ b/lib/store_app/common/app_page/page_layouts.dart
@@ -19,14 +19,19 @@ class PanedPageLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final height = windowSize.height;
     final width = windowSize.width;
-    final hPadding = 0.0004 * pow(width * 0.4, 2) - 20;
+    final hPadding = kPagePadding + 0.0004 * pow((width - 1200) * 0.8, 2);
     final appBarHeight =
         Theme.of(context).appBarTheme.toolbarHeight?.toDouble() ??
             kToolbarHeight;
 
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(kPagePadding),
+        padding: EdgeInsets.only(
+          top: kPagePadding,
+          bottom: kPagePadding,
+          left: hPadding,
+          right: hPadding,
+        ),
         child: SizedBox(
           height: height - appBarHeight,
           child: Row(

--- a/lib/store_app/common/border_container.dart
+++ b/lib/store_app/common/border_container.dart
@@ -37,6 +37,7 @@ class BorderContainer extends StatelessWidget {
     this.transformAlignment,
     this.clipBehavior = Clip.none,
     this.containerPadding,
+    this.borderColor,
   });
 
   /// Forwarded to [Container]
@@ -80,6 +81,9 @@ class BorderContainer extends StatelessWidget {
   /// Forwarded to [Container]
   final Clip clipBehavior;
 
+  /// Optional color for the border
+  final Color? borderColor;
+
   @override
   Widget build(BuildContext context) {
     final container = Container(
@@ -99,7 +103,7 @@ class BorderContainer extends StatelessWidget {
                 : Theme.of(context).colorScheme.onSurface.withOpacity(0.03)),
         borderRadius: BorderRadius.circular(borderRadius),
         border: Border.all(
-          color: Theme.of(context).dividerColor,
+          color: borderColor ?? Theme.of(context).dividerColor,
         ),
       ),
       child: child,

--- a/lib/store_app/common/constants.dart
+++ b/lib/store_app/common/constants.dart
@@ -24,7 +24,7 @@ const kGridPadding = EdgeInsets.only(
   right: kPagePadding,
 );
 const kHeaderPadding =
-    EdgeInsets.only(top: kPagePadding, left: 25, bottom: kPagePadding);
+    EdgeInsets.only(top: 25, left: 25, bottom: kPagePadding);
 const kIconPadding = EdgeInsets.only(top: 8, bottom: 8, right: 5);
 const kDialogWidth = 450.0;
 const kGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(

--- a/lib/store_app/common/constants.dart
+++ b/lib/store_app/common/constants.dart
@@ -17,7 +17,7 @@
 
 import 'package:flutter/material.dart';
 
-const kPagePadding = 25.0;
+const kPagePadding = 20.0;
 const kGridPadding = EdgeInsets.only(
   bottom: kPagePadding,
   left: kPagePadding,

--- a/lib/store_app/common/constants.dart
+++ b/lib/store_app/common/constants.dart
@@ -17,7 +17,7 @@
 
 import 'package:flutter/material.dart';
 
-const kPagePadding = 20.0;
+const kPagePadding = 25.0;
 const kGridPadding = EdgeInsets.only(
   bottom: kPagePadding,
   left: kPagePadding,

--- a/lib/store_app/common/packagekit/package_page.dart
+++ b/lib/store_app/common/packagekit/package_page.dart
@@ -27,7 +27,6 @@ import 'package:software/store_app/common/app_page/app_page.dart';
 import 'package:software/store_app/common/packagekit/package_controls.dart';
 import 'package:software/store_app/common/packagekit/package_model.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 class PackagePage extends StatefulWidget {
   const PackagePage({
@@ -129,9 +128,7 @@ class _PackagePageState extends State<PackagePage> {
             permissionContainer: null,
             icon: AppIcon(
               iconUrl: model.iconUrl,
-              fallBackIconData: YaruIcons.debian,
               size: 150,
-              fallBackIconSize: 50,
             ),
             controls: PackageControls(
               isInstalled: model.isInstalled,

--- a/lib/store_app/common/snap/snap_page.dart
+++ b/lib/store_app/common/snap/snap_page.dart
@@ -123,7 +123,6 @@ class _SnapPageState extends State<SnapPage> {
             icon: AppIcon(
               iconUrl: model.iconUrl,
               size: 150,
-              fallBackIconSize: 50,
             ),
           );
   }

--- a/lib/store_app/explore/color_banner.dart
+++ b/lib/store_app/explore/color_banner.dart
@@ -100,12 +100,10 @@ class _ColorBannerState extends State<ColorBanner> {
       icon: AppIcon(
         iconUrl: widget.snap.iconUrl,
         size: 80,
-        fallBackIconSize: 35,
       ),
       watermarkIcon: AppIcon(
         iconUrl: widget.snap.iconUrl,
         size: 130,
-        fallBackIconSize: 50,
       ),
     );
   }

--- a/lib/store_app/explore/explore_header.dart
+++ b/lib/store_app/explore/explore_header.dart
@@ -4,6 +4,7 @@ import 'package:software/store_app/common/app_format.dart';
 import 'package:software/store_app/common/app_format_popup.dart';
 import 'package:software/store_app/common/snap/snap_section_popup.dart';
 import 'package:software/store_app/explore/explore_model.dart';
+import 'package:software/store_app/common/constants.dart';
 
 class ExploreHeader extends StatelessWidget {
   const ExploreHeader({super.key});
@@ -13,7 +14,7 @@ class ExploreHeader extends StatelessWidget {
     final model = context.watch<ExploreModel>();
 
     return Padding(
-      padding: const EdgeInsets.only(top: 20, left: 25, bottom: 20),
+      padding: kHeaderPadding,
       child: Align(
         alignment: Alignment.centerLeft,
         child: Wrap(

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -86,9 +86,7 @@ class _SnapSearchPage extends StatelessWidget {
                       ),
                       icon: AppIcon(
                         iconUrl: snap.iconUrl,
-                        fallBackIconData: YaruIcons.snapcraft,
                         size: 50,
-                        fallBackIconSize: 30,
                       ),
                       iconPadding: const EdgeInsets.only(left: 10, right: 5),
                       onTap: () => SnapPage.push(context, snap),
@@ -149,7 +147,6 @@ class _PackageKitSearchPageState extends State<_PackageKitSearchPage> {
                     subtitle: Text(id.version),
                     icon: const AppIcon(
                       iconUrl: null,
-                      fallBackIconData: YaruIcons.debian,
                     ),
                     iconPadding: const EdgeInsets.only(left: 10, right: 5),
                     onTap: () => PackagePage.push(context, id),
@@ -298,7 +295,6 @@ class _CombinedSearchPage extends StatelessWidget {
                     ),
                     icon: AppIcon(
                       iconUrl: e.value.snap?.iconUrl,
-                      fallBackIconData: YaruIcons.view_more,
                     ),
                     iconPadding:
                         const EdgeInsets.only(left: 10, right: 5, bottom: 30),

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -80,9 +80,6 @@ class SectionBanner extends StatelessWidget {
                             child: AppIcon(
                               iconUrl: e.iconUrl,
                               size: 65,
-                              fallBackIconColor:
-                                  const Color.fromARGB(255, 109, 109, 109),
-                              fallBackIconSize: 40,
                             ),
                           ),
                         ),

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -74,14 +74,8 @@ class SectionBanner extends StatelessWidget {
                   spacing: kYaruPagePadding,
                   children: snaps
                       .map(
-                        (e) => InkWell(
-                          onTap: () => SnapPage.push(context, e),
-                          child: _IconContainer(
-                            child: AppIcon(
-                              iconUrl: e.iconUrl,
-                              size: 65,
-                            ),
-                          ),
+                        (e) => _PlatedIcon(
+                          snap: e,
                         ),
                       )
                       .toList(),
@@ -98,11 +92,48 @@ class SectionBanner extends StatelessWidget {
   }
 }
 
-class _IconContainer extends StatelessWidget {
-  // ignore: unused_element
-  const _IconContainer({super.key, required this.child});
+class _PlatedIcon extends StatefulWidget {
+  const _PlatedIcon({
+    // ignore: unused_element
+    super.key,
+    required this.snap,
+  });
+
+  final Snap snap;
+
+  @override
+  State<_PlatedIcon> createState() => _PlatedIconState();
+}
+
+class _PlatedIconState extends State<_PlatedIcon> {
+  bool hovered = false;
+  final dur = const Duration(milliseconds: 100);
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => SnapPage.push(context, widget.snap),
+      onHover: (value) => setState(() => hovered = value),
+      child: _BasePlate(
+        hovered: hovered,
+        child: AppIcon(
+          iconUrl: widget.snap.iconUrl,
+          size: 65,
+        ),
+      ),
+    );
+  }
+}
+
+class _BasePlate extends StatelessWidget {
+  const _BasePlate({
+    // ignore: unused_element
+    super.key,
+    required this.child,
+    required this.hovered,
+  });
 
   final Widget child;
+  final bool hovered;
 
   @override
   Widget build(BuildContext context) {
@@ -112,7 +143,7 @@ class _IconContainer extends StatelessWidget {
         borderRadius: BorderRadius.circular(10),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.15),
+            color: Colors.black.withOpacity(hovered ? 0.4 : 0.15),
             spreadRadius: 3,
             blurRadius: 5,
             offset: const Offset(0, 1), // changes position of shadow

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -110,6 +110,7 @@ class _PlatedIconState extends State<_PlatedIcon> {
   final dur = const Duration(milliseconds: 100);
   @override
   Widget build(BuildContext context) {
+    final dark = Theme.of(context).brightness == Brightness.dark;
     return InkWell(
       onTap: () => SnapPage.push(context, widget.snap),
       onHover: (value) => setState(() => hovered = value),
@@ -117,6 +118,8 @@ class _PlatedIconState extends State<_PlatedIcon> {
         hovered: hovered,
         child: AppIcon(
           iconUrl: widget.snap.iconUrl,
+          color: dark ? Colors.black.withOpacity(0.1) : null,
+          borderColor: dark ? Colors.white : null,
           size: 65,
         ),
       ),
@@ -137,7 +140,8 @@ class _BasePlate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(10),

--- a/lib/store_app/my_apps/my_packages_page.dart
+++ b/lib/store_app/my_apps/my_packages_page.dart
@@ -22,7 +22,6 @@ import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
 import 'package:software/store_app/common/packagekit/package_page.dart';
 import 'package:software/store_app/my_apps/my_apps_model.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class MyPackagesPage extends StatefulWidget {
@@ -74,7 +73,6 @@ class _MyPackagesPageState extends State<MyPackagesPage> {
                   iconPadding: const EdgeInsets.only(left: 10, right: 5),
                   icon: const AppIcon(
                     iconUrl: null,
-                    fallBackIconData: YaruIcons.debian,
                   ),
                 ),
               );

--- a/lib/store_app/updates/update_dialog.dart
+++ b/lib/store_app/updates/update_dialog.dart
@@ -203,7 +203,6 @@ class _UpdateDialogState extends State<UpdateDialog> {
                 children: [
                   const AppIcon(
                     iconUrl: null,
-                    fallBackIconData: YaruIcons.debian,
                   ),
                   const SizedBox(
                     width: 10,


### PR DESCRIPTION
The padding around the headerbar was a tad inconsistent, with padding on the top and bottom at 20 and on the sides at 25. The PannedPageLayout is also using the wrong value for the padding on the right and I made the HeaderBar in the explore page use constants. 

<details>

<summary>HeaderBar before: </summary>

![Screenshot from 2022-11-18 00-12-34](https://user-images.githubusercontent.com/73116038/202589979-2023641a-be64-4d06-ab41-c108b7065018.png)


</details>

<details>

<summary>HeaderBar after:</summary>

![Screenshot from 2022-11-18 00-32-38](https://user-images.githubusercontent.com/73116038/202589619-d38ac684-fef1-420b-81d8-8312f4eb085d.png)

</details>

<details>

<summary>PannedPageLayout before</summary>

![Screenshot from 2022-11-18 00-25-40](https://user-images.githubusercontent.com/73116038/202589738-0f701d9a-38b7-4770-9b92-93c9b356a052.png)

</details>


<details>

<summary>PannedPageLayout after:</summary>

![Screenshot from 2022-11-18 00-27-48](https://user-images.githubusercontent.com/73116038/202589694-98ef05e1-6efc-46fe-a3e5-1b21fb044191.png)

</details>

Fixes #534 