### PR TITLE
AppIcon: use an app format agnostic fallback icon

### DIFF
--- a/lib/store_app/common/app_icon.dart
+++ b/lib/store_app/common/app_icon.dart
@@ -15,38 +15,30 @@
  *
  */
 
-import 'package:flutter/widgets.dart';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
 import 'package:software/store_app/common/border_container.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 class AppIcon extends StatelessWidget {
   const AppIcon({
     super.key,
     required this.iconUrl,
-    this.fallBackIconData = YaruIcons.snapcraft,
     this.size = 45,
-    this.fallBackIconSize = 20,
-    this.fallBackIconColor,
   });
 
   final String? iconUrl;
-  final IconData fallBackIconData;
   final double size;
-  final double fallBackIconSize;
-  final Color? fallBackIconColor;
 
   @override
   Widget build(BuildContext context) {
     final fallBackIcon = BorderContainer(
+      clipBehavior: Clip.hardEdge,
       containerPadding: EdgeInsets.zero,
       borderRadius: 200,
       width: size,
       height: size,
-      child: Icon(
-        fallBackIconData,
-        size: fallBackIconSize,
-        color: fallBackIconColor,
-      ),
+      child: _FallBackIcon(size: size),
     );
 
     return iconUrl == null || iconUrl!.isEmpty
@@ -64,5 +56,85 @@ class AppIcon extends StatelessWidget {
               errorBuilder: (context, error, stackTrace) => fallBackIcon,
             ),
           );
+  }
+}
+
+class _FallBackIcon extends StatelessWidget {
+  const _FallBackIcon({
+    Key? key,
+    required this.size,
+  }) : super(key: key);
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final light = theme.brightness == Brightness.light;
+    final border = BorderSide(
+      color: light ? Colors.white : theme.dividerColor,
+      width: light ? 0.5 : 0.3,
+    );
+    final shadeMax = light
+        ? theme.dividerColor.withOpacity(0.1)
+        : theme.colorScheme.onSurface.withOpacity(0.03);
+    final shadeMid = light
+        ? theme.dividerColor.withOpacity(0.05)
+        : theme.colorScheme.onSurface.withOpacity(0.015);
+    final shadeMin = light
+        ? theme.dividerColor.withOpacity(0.005)
+        : theme.colorScheme.onSurface.withOpacity(0.005);
+    return ClipOval(
+      child: FittedBox(
+        fit: BoxFit.none,
+        child: Transform.rotate(
+          angle: -pi / 4,
+          child: Row(
+            children: [
+              Column(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(size),
+                    decoration: BoxDecoration(
+                      border: Border(
+                        right: border,
+                      ),
+                      color: shadeMid,
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.all(size),
+                    decoration: BoxDecoration(
+                      color: shadeMax,
+                      border: Border(
+                        top: border,
+                        right: border,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(size * 1.2),
+                    decoration: BoxDecoration(
+                      color: shadeMin,
+                      border: Border(
+                        bottom: border,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.all(size * 1.2),
+                    decoration: BoxDecoration(color: shadeMid),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/store_app/common/packagekit/package_page.dart
+++ b/lib/store_app/common/packagekit/package_page.dart
@@ -27,7 +27,6 @@ import 'package:software/store_app/common/app_page/app_page.dart';
 import 'package:software/store_app/common/packagekit/package_controls.dart';
 import 'package:software/store_app/common/packagekit/package_model.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 
 class PackagePage extends StatefulWidget {
   const PackagePage({
@@ -129,9 +128,7 @@ class _PackagePageState extends State<PackagePage> {
             permissionContainer: null,
             icon: AppIcon(
               iconUrl: model.iconUrl,
-              fallBackIconData: YaruIcons.debian,
               size: 150,
-              fallBackIconSize: 50,
             ),
             controls: PackageControls(
               isInstalled: model.isInstalled,

--- a/lib/store_app/common/snap/snap_page.dart
+++ b/lib/store_app/common/snap/snap_page.dart
@@ -123,7 +123,6 @@ class _SnapPageState extends State<SnapPage> {
             icon: AppIcon(
               iconUrl: model.iconUrl,
               size: 150,
-              fallBackIconSize: 50,
             ),
           );
   }

--- a/lib/store_app/explore/color_banner.dart
+++ b/lib/store_app/explore/color_banner.dart
@@ -100,12 +100,10 @@ class _ColorBannerState extends State<ColorBanner> {
       icon: AppIcon(
         iconUrl: widget.snap.iconUrl,
         size: 80,
-        fallBackIconSize: 35,
       ),
       watermarkIcon: AppIcon(
         iconUrl: widget.snap.iconUrl,
         size: 130,
-        fallBackIconSize: 50,
       ),
     );
   }

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -86,9 +86,7 @@ class _SnapSearchPage extends StatelessWidget {
                       ),
                       icon: AppIcon(
                         iconUrl: snap.iconUrl,
-                        fallBackIconData: YaruIcons.snapcraft,
                         size: 50,
-                        fallBackIconSize: 30,
                       ),
                       iconPadding: const EdgeInsets.only(left: 10, right: 5),
                       onTap: () => SnapPage.push(context, snap),
@@ -149,7 +147,6 @@ class _PackageKitSearchPageState extends State<_PackageKitSearchPage> {
                     subtitle: Text(id.version),
                     icon: const AppIcon(
                       iconUrl: null,
-                      fallBackIconData: YaruIcons.debian,
                     ),
                     iconPadding: const EdgeInsets.only(left: 10, right: 5),
                     onTap: () => PackagePage.push(context, id),
@@ -298,7 +295,6 @@ class _CombinedSearchPage extends StatelessWidget {
                     ),
                     icon: AppIcon(
                       iconUrl: e.value.snap?.iconUrl,
-                      fallBackIconData: YaruIcons.view_more,
                     ),
                     iconPadding:
                         const EdgeInsets.only(left: 10, right: 5, bottom: 30),

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -80,9 +80,6 @@ class SectionBanner extends StatelessWidget {
                             child: AppIcon(
                               iconUrl: e.iconUrl,
                               size: 65,
-                              fallBackIconColor:
-                                  const Color.fromARGB(255, 109, 109, 109),
-                              fallBackIconSize: 40,
                             ),
                           ),
                         ),

--- a/lib/store_app/my_apps/my_packages_page.dart
+++ b/lib/store_app/my_apps/my_packages_page.dart
@@ -22,7 +22,6 @@ import 'package:software/store_app/common/app_icon.dart';
 import 'package:software/store_app/common/constants.dart';
 import 'package:software/store_app/common/packagekit/package_page.dart';
 import 'package:software/store_app/my_apps/my_apps_model.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class MyPackagesPage extends StatefulWidget {
@@ -74,7 +73,6 @@ class _MyPackagesPageState extends State<MyPackagesPage> {
                   iconPadding: const EdgeInsets.only(left: 10, right: 5),
                   icon: const AppIcon(
                     iconUrl: null,
-                    fallBackIconData: YaruIcons.debian,
                   ),
                 ),
               );

--- a/lib/store_app/updates/update_dialog.dart
+++ b/lib/store_app/updates/update_dialog.dart
@@ -203,7 +203,6 @@ class _UpdateDialogState extends State<UpdateDialog> {
                 children: [
                   const AppIcon(
                     iconUrl: null,
-                    fallBackIconData: YaruIcons.debian,
                   ),
                   const SizedBox(
                     width: 10,


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/15329494/202642036-057acc4e-e57e-4e65-b34c-defef8d56574.png)
![grafik](https://user-images.githubusercontent.com/15329494/202642071-7ce2ce41-93dd-44ea-adac-76c569808831.png)
![grafik](https://user-images.githubusercontent.com/15329494/202642132-d2e4135d-e8d9-4ee8-92d0-31fc2368c42b.png)
![grafik](https://user-images.githubusercontent.com/15329494/202642153-707133ac-a3e6-44de-8477-05e779291a16.png)
