### PR TITLE
AppIcon refinements for the sectionbanner

### DIFF
--- a/lib/store_app/common/app_icon.dart
+++ b/lib/store_app/common/app_icon.dart
@@ -25,20 +25,28 @@ class AppIcon extends StatelessWidget {
     super.key,
     required this.iconUrl,
     this.size = 45,
+    this.borderColor,
+    this.color,
   });
 
   final String? iconUrl;
   final double size;
+  final Color? borderColor;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
     final fallBackIcon = BorderContainer(
-      clipBehavior: Clip.hardEdge,
+      borderColor: color,
       containerPadding: EdgeInsets.zero,
       borderRadius: 200,
       width: size,
       height: size,
-      child: _FallBackIcon(size: size),
+      child: _FallBackIcon(
+        size: size,
+        borderColor: borderColor,
+        color: color,
+      ),
     );
 
     return iconUrl == null || iconUrl!.isEmpty
@@ -63,27 +71,37 @@ class _FallBackIcon extends StatelessWidget {
   const _FallBackIcon({
     Key? key,
     required this.size,
+    this.borderColor,
+    this.color,
   }) : super(key: key);
 
   final double size;
+  final Color? borderColor;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final light = theme.brightness == Brightness.light;
     final border = BorderSide(
-      color: light ? Colors.white : theme.dividerColor,
+      color: borderColor ?? (light ? Colors.white : theme.dividerColor),
       width: light ? 0.5 : 0.3,
     );
-    final shadeMax = light
-        ? theme.dividerColor.withOpacity(0.1)
-        : theme.colorScheme.onSurface.withOpacity(0.03);
-    final shadeMid = light
-        ? theme.dividerColor.withOpacity(0.05)
-        : theme.colorScheme.onSurface.withOpacity(0.015);
-    final shadeMin = light
-        ? theme.dividerColor.withOpacity(0.005)
-        : theme.colorScheme.onSurface.withOpacity(0.005);
+    final shadeMax = color != null
+        ? color!.withOpacity(0.1)
+        : light
+            ? theme.dividerColor.withOpacity(0.1)
+            : theme.colorScheme.onSurface.withOpacity(0.03);
+    final shadeMid = color != null
+        ? color!.withOpacity(0.05)
+        : light
+            ? theme.dividerColor.withOpacity(0.05)
+            : theme.colorScheme.onSurface.withOpacity(0.015);
+    final shadeMin = color != null
+        ? color!.withOpacity(0.005)
+        : light
+            ? theme.dividerColor.withOpacity(0.005)
+            : theme.colorScheme.onSurface.withOpacity(0.005);
     return ClipOval(
       child: FittedBox(
         fit: BoxFit.none,

--- a/lib/store_app/common/border_container.dart
+++ b/lib/store_app/common/border_container.dart
@@ -37,6 +37,7 @@ class BorderContainer extends StatelessWidget {
     this.transformAlignment,
     this.clipBehavior = Clip.none,
     this.containerPadding,
+    this.borderColor,
   });
 
   /// Forwarded to [Container]
@@ -80,6 +81,9 @@ class BorderContainer extends StatelessWidget {
   /// Forwarded to [Container]
   final Clip clipBehavior;
 
+  /// Optional color for the border
+  final Color? borderColor;
+
   @override
   Widget build(BuildContext context) {
     final container = Container(
@@ -99,7 +103,7 @@ class BorderContainer extends StatelessWidget {
                 : Theme.of(context).colorScheme.onSurface.withOpacity(0.03)),
         borderRadius: BorderRadius.circular(borderRadius),
         border: Border.all(
-          color: Theme.of(context).dividerColor,
+          color: borderColor ?? Theme.of(context).dividerColor,
         ),
       ),
       child: child,

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -110,6 +110,7 @@ class _PlatedIconState extends State<_PlatedIcon> {
   final dur = const Duration(milliseconds: 100);
   @override
   Widget build(BuildContext context) {
+    final dark = Theme.of(context).brightness == Brightness.dark;
     return InkWell(
       onTap: () => SnapPage.push(context, widget.snap),
       onHover: (value) => setState(() => hovered = value),
@@ -117,6 +118,8 @@ class _PlatedIconState extends State<_PlatedIcon> {
         hovered: hovered,
         child: AppIcon(
           iconUrl: widget.snap.iconUrl,
+          color: dark ? Colors.black.withOpacity(0.1) : null,
+          borderColor: dark ? Colors.white : null,
           size: 65,
         ),
       ),
@@ -137,7 +140,8 @@ class _BasePlate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
- add optional border color to border container
- set it to be visible on the white base plate of the app icons in the section banner
- animate the base plate on hover