### PR TITLE
Small padding adjustements - Center the apps page

### DIFF
--- a/lib/store_app/common/app_page/page_layouts.dart
+++ b/lib/store_app/common/app_page/page_layouts.dart
@@ -19,7 +19,7 @@ class PanedPageLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final height = windowSize.height;
     final width = windowSize.width;
-    final hPadding = 0.0004 * pow(width * 0.4, 2) - 20;
+    final hPadding = kPagePadding + 0.0004 * pow((width - 1200) * 0.8, 2);
     final appBarHeight =
         Theme.of(context).appBarTheme.toolbarHeight?.toDouble() ??
             kToolbarHeight;
@@ -29,7 +29,7 @@ class PanedPageLayout extends StatelessWidget {
         padding: EdgeInsets.only(
           top: kPagePadding,
           bottom: kPagePadding,
-          left: kPagePadding,
+          left: hPadding,
           right: hPadding,
         ),
         child: SizedBox(

--- a/lib/store_app/common/constants.dart
+++ b/lib/store_app/common/constants.dart
@@ -17,7 +17,7 @@
 
 import 'package:flutter/material.dart';
 
-const kPagePadding = 25.0;
+const kPagePadding = 20.0;
 const kGridPadding = EdgeInsets.only(
   bottom: kPagePadding,
   left: kPagePadding,

--- a/lib/store_app/common/constants.dart
+++ b/lib/store_app/common/constants.dart
@@ -17,7 +17,7 @@
 
 import 'package:flutter/material.dart';
 
-const kPagePadding = 20.0;
+const kPagePadding = 25.0;
 const kGridPadding = EdgeInsets.only(
   bottom: kPagePadding,
   left: kPagePadding,

--- a/lib/store_app/explore/explore_header.dart
+++ b/lib/store_app/explore/explore_header.dart
@@ -13,7 +13,7 @@ class ExploreHeader extends StatelessWidget {
     final model = context.watch<ExploreModel>();
 
     return Padding(
-      padding: const EdgeInsets.only(top: 20, left: 25, bottom: 20),
+      padding: const EdgeInsets.only(top: 25, left: 25, bottom: 20),
       child: Align(
         alignment: Alignment.centerLeft,
         child: Wrap(

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -27,6 +27,7 @@ class SectionBanner extends StatelessWidget {
       constraints: const BoxConstraints(minHeight: 230),
       child: Padding(
         padding: const EdgeInsets.only(
+          top: 5,
           left: kYaruPagePadding + 5,
           right: kYaruPagePadding + 5,
           bottom: kYaruPagePadding + 5,

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -30,7 +30,7 @@ class SectionBanner extends StatelessWidget {
           top: 5,
           left: kYaruPagePadding + 5,
           right: kYaruPagePadding + 5,
-          bottom: kYaruPagePadding + 5,
+          bottom: kYaruPagePadding,
         ),
         child: InkWell(
           onTap: onTap,


### PR DESCRIPTION
Hey sorry, I tried to rebase the last pull request but something seems to have gone horribly wrong.

Like the last PR, this makes all of the padding in the explore page 25px. 

As for the apps page, I thought that it would look better if the entire page was centred in addition to it changing back to a single page view once the padding on the left and right equal 20 (or kPagePadding). This still conforms to the ultra-wide monitors aspect-ratio.

before:

https://user-images.githubusercontent.com/73116038/203015107-3658f93c-710a-46be-ab08-fbbeaa8789f8.mp4


after:

https://user-images.githubusercontent.com/73116038/203015092-43b9f1ba-0c7c-4248-b6f6-59871acf2df7.mp4



What do you think? @Feichtmeier 

Fixes #534 