### PR TITLE
Improve linting and code analysing

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,3 +12,27 @@ linter:
     prefer_const_constructors: true
     prefer_const_declarations: true
     require_trailing_commas: true
+    always_declare_return_types: true
+    avoid_catches_without_on_clauses: true
+    avoid_equals_and_hash_code_on_mutable_classes: true
+    avoid_types_on_closure_parameters: true
+    depend_on_referenced_packages: true
+    directives_ordering: true
+    eol_at_end_of_file: true
+    omit_local_variable_types: true
+    prefer_asserts_in_initializer_lists: true
+    prefer_final_in_for_each: true
+    prefer_final_locals: true
+    prefer_null_aware_method_calls: true
+    prefer_null_aware_operators: true
+    prefer_relative_imports: true
+    sort_constructors_first: true
+    sort_unnamed_constructors_first: true
+    sort_pub_dependencies: true
+    type_annotate_public_apis: true
+    unawaited_futures: true
+    unnecessary_lambdas: true
+    unnecessary_late: true
+    unnecessary_parenthesis: true
+    use_named_constants: true
+    use_super_parameters: true

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -15,8 +15,8 @@
  *
  */
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 export 'package:flutter_gen/gen_l10n/app_localizations.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,24 +15,27 @@
  *
  */
 
+import 'dart:async';
+
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/package_installer/package_installer_app.dart';
-import 'package:software/services/color_generator.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/store_app/store_app.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'package_installer/package_installer_app.dart';
+import 'services/color_generator.dart';
+import 'services/package_service.dart';
+import 'services/snap_service.dart';
+import 'store_app/store_app.dart';
+
 Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
   await windowManager.ensureInitialized();
-  windowManager.setPreventClose(false);
+  unawaited(windowManager.setPreventClose(false));
 
   registerService<NotificationsClient>(
     NotificationsClient.new,

--- a/lib/package_installer/package_installer_app.dart
+++ b/lib/package_installer/package_installer_app.dart
@@ -18,19 +18,20 @@
 import 'package:flutter/material.dart';
 import 'package:liquid_progress_indicator/liquid_progress_indicator.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/package_installer/wizard_page.dart';
-import 'package:software/package_state.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/store_app/common/packagekit/package_model.dart';
-import 'package:software/store_app/common/utils.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../l10n/l10n.dart';
+import '../package_state.dart';
+import '../services/package_service.dart';
+import '../store_app/common/packagekit/package_model.dart';
+import '../store_app/common/utils.dart';
+import 'wizard_page.dart';
+
 class PackageInstallerApp extends StatelessWidget {
-  const PackageInstallerApp({Key? key, required this.path}) : super(key: key);
+  const PackageInstallerApp({super.key, required this.path});
 
   final String path;
 
@@ -97,7 +98,7 @@ class _PackageInstallerPageState extends State<_PackageInstallerPage> {
                     model.packageId!.name.isEmpty ||
                     model.packageState == PackageState.processing
                 ? null
-                : () => model.remove(),
+                : model.remove,
             child: Text(context.l10n.remove),
           )
         else
@@ -106,7 +107,7 @@ class _PackageInstallerPageState extends State<_PackageInstallerPage> {
                     model.packageId!.name.isEmpty ||
                     model.packageState != PackageState.ready
                 ? null
-                : () => model.install(),
+                : model.install,
             child: Text(context.l10n.install),
           ),
       ],

--- a/lib/package_installer/wizard_page.dart
+++ b/lib/package_installer/wizard_page.dart
@@ -16,7 +16,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/store_app/common/constants.dart';
+import '../store_app/common/constants.dart';
 
 /// The padding around the content.
 const _kWizardContentPadding = EdgeInsets.symmetric(horizontal: 24);
@@ -34,7 +34,7 @@ const _kWizardFooterPadding = EdgeInsets.fromLTRB(24, 0, 24, 24);
 class WizardPage extends StatefulWidget {
   /// Creates the wizard page.
   const WizardPage({
-    Key? key,
+    super.key,
     this.title,
     this.header,
     this.headerPadding = _kWizardHeaderPadding,
@@ -43,7 +43,7 @@ class WizardPage extends StatefulWidget {
     this.footer,
     this.footerPadding = _kWizardFooterPadding,
     this.actions = const <Widget>[],
-  }) : super(key: key);
+  });
 
   /// The title widget in the app bar.
   final Widget? title;

--- a/lib/packagekit_filter_x.dart
+++ b/lib/packagekit_filter_x.dart
@@ -1,5 +1,5 @@
 import 'package:packagekit/packagekit.dart';
-import 'package:software/l10n/l10n.dart';
+import 'l10n/l10n.dart';
 
 extension PackageKitFilterX on PackageKitFilter {
   String localize(AppLocalizations l10n) {

--- a/lib/packagekit_group_x.dart
+++ b/lib/packagekit_group_x.dart
@@ -1,5 +1,5 @@
 import 'package:packagekit/packagekit.dart';
-import 'package:software/l10n/l10n.dart';
+import 'l10n/l10n.dart';
 
 extension PackageKitGroupX on PackageKitGroup {
   String localize(AppLocalizations l10n) {

--- a/lib/services/package_service.dart
+++ b/lib/services/package_service.dart
@@ -454,10 +454,12 @@ class PackageService {
         completer.complete();
       }
     });
-    unawaited(transaction.searchNames(
-      [model.packageId!.name],
-      filter: {PackageKitFilter.installed},
-    ));
+    unawaited(
+      transaction.searchNames(
+        [model.packageId!.name],
+        filter: {PackageKitFilter.installed},
+      ),
+    );
     return completer.future.whenComplete(subscription.cancel);
   }
 

--- a/lib/store_app/common/animated_scroll_view_item.dart
+++ b/lib/store_app/common/animated_scroll_view_item.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart';
 /// https://github.com/Roaa94
 class AnimatedScrollViewItem extends StatefulWidget {
   const AnimatedScrollViewItem({
-    Key? key,
+    super.key,
     required this.child,
-  }) : super(key: key);
+  });
 
   final Widget child;
 

--- a/lib/store_app/common/app_data.dart
+++ b/lib/store_app/common/app_data.dart
@@ -16,24 +16,6 @@
  */
 
 class AppData {
-  final String title;
-  final String name;
-  final String summary;
-  final bool strict;
-  final String confinementName;
-  final String version;
-  final String license;
-  final String? installDate;
-  final String? installDateIsoNorm;
-  final bool verified;
-  final bool starredDeveloper;
-  final String? publisherName;
-  final String website;
-  final List<String> screenShotUrls;
-  final String description;
-  final bool? versionChanged;
-  final double? averageRating;
-  final List<AppReview>? userReviews;
 
   AppData({
     required this.title,
@@ -55,17 +37,27 @@ class AppData {
     this.averageRating,
     this.userReviews,
   });
+  final String title;
+  final String name;
+  final String summary;
+  final bool strict;
+  final String confinementName;
+  final String version;
+  final String license;
+  final String? installDate;
+  final String? installDateIsoNorm;
+  final bool verified;
+  final bool starredDeveloper;
+  final String? publisherName;
+  final String website;
+  final List<String> screenShotUrls;
+  final String description;
+  final bool? versionChanged;
+  final double? averageRating;
+  final List<AppReview>? userReviews;
 }
 
 class AppReview {
-  final int? id;
-  final double? rating;
-  final String? review;
-  final String? title;
-  final DateTime? dateTime;
-  final String? username;
-  final int? positiveVote;
-  final int? negativeVote;
 
   AppReview({
     this.id,
@@ -77,4 +69,12 @@ class AppReview {
     this.positiveVote,
     this.negativeVote,
   });
+  final int? id;
+  final double? rating;
+  final String? review;
+  final String? title;
+  final DateTime? dateTime;
+  final String? username;
+  final int? positiveVote;
+  final int? negativeVote;
 }

--- a/lib/store_app/common/app_format.dart
+++ b/lib/store_app/common/app_format.dart
@@ -16,8 +16,9 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+
+import '../../l10n/l10n.dart';
 
 enum AppFormat {
   snap,

--- a/lib/store_app/common/app_format_popup.dart
+++ b/lib/store_app/common/app_format_popup.dart
@@ -16,9 +16,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/app_format.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n/l10n.dart';
+import 'app_format.dart';
 
 class AppFormatPopup extends StatelessWidget {
   const AppFormatPopup({

--- a/lib/store_app/common/app_icon.dart
+++ b/lib/store_app/common/app_icon.dart
@@ -18,7 +18,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:software/store_app/common/border_container.dart';
+import 'border_container.dart';
 
 class AppIcon extends StatelessWidget {
   const AppIcon({
@@ -69,11 +69,10 @@ class AppIcon extends StatelessWidget {
 
 class _FallBackIcon extends StatelessWidget {
   const _FallBackIcon({
-    Key? key,
     required this.size,
     this.borderColor,
     this.color,
-  }) : super(key: key);
+  });
 
   final double size;
   final Color? borderColor;

--- a/lib/store_app/common/app_model.dart
+++ b/lib/store_app/common/app_model.dart
@@ -1,6 +1,6 @@
 import 'package:safe_change_notifier/safe_change_notifier.dart';
-import 'package:software/store_app/common/app_data.dart';
-import 'package:software/store_app/common/constants.dart';
+import 'app_data.dart';
+import 'constants.dart';
 
 // TODO: adapt to Rating backend when ready
 class AppModel extends SafeChangeNotifier {

--- a/lib/store_app/common/app_page/app_description.dart
+++ b/lib/store_app/common/app_page/app_description.dart
@@ -17,10 +17,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
 
 class AppDescription extends StatelessWidget {
   const AppDescription({super.key, required this.description});

--- a/lib/store_app/common/app_page/app_header.dart
+++ b/lib/store_app/common/app_page/app_header.dart
@@ -17,13 +17,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
-import 'package:software/store_app/common/app_data.dart';
-import 'package:software/store_app/common/app_page/app_infos.dart';
-import 'package:software/store_app/common/app_website.dart';
-import 'package:software/store_app/common/constants.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../app_data.dart';
+import '../app_website.dart';
+import '../constants.dart';
+import 'app_infos.dart';
 
 const headerStyle = TextStyle(fontWeight: FontWeight.w500, fontSize: 14);
 const iconSize = 150.0;
@@ -42,7 +43,7 @@ class BannerAppHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scaledFontSize = (800 / appData.title.length.toDouble());
+    final scaledFontSize = 800 / appData.title.length.toDouble();
     return Column(
       children: [
         Row(
@@ -132,7 +133,7 @@ class PageAppHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scaledFontSize = (800 / appData.title.length.toDouble());
+    final scaledFontSize = 800 / appData.title.length.toDouble();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/lib/store_app/common/app_page/app_infos.dart
+++ b/lib/store_app/common/app_page/app_infos.dart
@@ -16,15 +16,16 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/constants.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+
+import '../../../l10n/l10n.dart';
+import '../constants.dart';
 
 const headerStyle = TextStyle(fontWeight: FontWeight.w500, fontSize: 14);
 
 class AppInfos extends StatelessWidget {
   const AppInfos({
-    Key? key,
+    super.key,
     required this.strict,
     required this.confinementName,
     required this.license,
@@ -36,7 +37,7 @@ class AppInfos extends StatelessWidget {
     this.wrapAlignment = WrapAlignment.center,
     this.runAlignment = WrapAlignment.center,
     this.direction = Axis.horizontal,
-  }) : super(key: key);
+  });
 
   final bool strict;
   final String confinementName;
@@ -94,10 +95,9 @@ class AppInfos extends StatelessWidget {
 
 class _InstallDate extends StatelessWidget {
   const _InstallDate({
-    Key? key,
     required this.installDateIsoNorm,
     required this.installDate,
-  }) : super(key: key);
+  });
 
   final String installDateIsoNorm;
   final String installDate;
@@ -120,12 +120,11 @@ class _InstallDate extends StatelessWidget {
 
 class _InfoColumn extends StatelessWidget {
   const _InfoColumn({
-    Key? key,
     required this.header,
     required this.child,
     required this.tooltipMessage,
     this.childWidth,
-  }) : super(key: key);
+  });
 
   final String header;
   final String tooltipMessage;
@@ -158,10 +157,9 @@ class _InfoColumn extends StatelessWidget {
 
 class _Version extends StatelessWidget {
   const _Version({
-    Key? key,
     required this.version,
     this.versionChanged,
-  }) : super(key: key);
+  });
 
   final String version;
   final bool? versionChanged;
@@ -190,10 +188,9 @@ class _Version extends StatelessWidget {
 
 class _License extends StatelessWidget {
   const _License({
-    Key? key,
     required this.headerStyle,
     required this.license,
-  }) : super(key: key);
+  });
 
   final TextStyle headerStyle;
   final String license;
@@ -215,10 +212,9 @@ class _License extends StatelessWidget {
 
 class _Confinement extends StatelessWidget {
   const _Confinement({
-    Key? key,
     required this.strict,
     required this.confinementName,
-  }) : super(key: key);
+  });
 
   final bool strict;
   final String confinementName;

--- a/lib/store_app/common/app_page/app_loading_page.dart
+++ b/lib/store_app/common/app_page/app_loading_page.dart
@@ -17,9 +17,10 @@
 
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:software/store_app/common/app_page/page_layouts.dart';
-import 'package:software/store_app/common/border_container.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+
+import '../border_container.dart';
+import 'page_layouts.dart';
 
 class AppLoadingPage extends StatelessWidget {
   const AppLoadingPage({
@@ -33,7 +34,7 @@ class AppLoadingPage extends StatelessWidget {
     final isWindowNormalSized = windowWidth > 800 && windowWidth < 1200;
     final isWindowWide = windowWidth > 1200;
 
-    var light = Theme.of(context).brightness == Brightness.light;
+    final light = Theme.of(context).brightness == Brightness.light;
     final shimmerBase = light
         ? const Color.fromARGB(120, 228, 228, 228)
         : Theme.of(context).colorScheme.onSurface.withOpacity(0.03);
@@ -165,9 +166,8 @@ class AppLoadingPage extends StatelessWidget {
 
 class _CustomBackButton extends StatelessWidget {
   const _CustomBackButton({
-    Key? key,
     this.onPressed,
-  }) : super(key: key);
+  });
 
   final Function()? onPressed;
 
@@ -178,7 +178,7 @@ class _CustomBackButton extends StatelessWidget {
         style: IconButton.styleFrom(fixedSize: const Size(40, 40)),
         onPressed: () {
           Navigator.maybePop(context);
-          if (onPressed != null) onPressed!();
+          if (onPressed != null) onPressed!.call();
         },
         icon: const Icon(YaruIcons.go_previous),
       ),

--- a/lib/store_app/common/app_page/app_page.dart
+++ b/lib/store_app/common/app_page/app_page.dart
@@ -17,17 +17,18 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:software/store_app/common/app_data.dart';
-import 'package:software/store_app/common/app_page/app_description.dart';
-import 'package:software/store_app/common/app_page/app_header.dart';
-import 'package:software/store_app/common/app_page/app_infos.dart';
-import 'package:software/store_app/common/app_page/app_reviews.dart';
-import 'package:software/store_app/common/app_page/media_tile.dart';
-import 'package:software/store_app/common/app_page/page_layouts.dart';
-import 'package:software/store_app/common/border_container.dart';
-import 'package:software/store_app/common/safe_network_image.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../app_data.dart';
+import '../border_container.dart';
+import '../safe_network_image.dart';
+import 'app_description.dart';
+import 'app_header.dart';
+import 'app_infos.dart';
+import 'app_reviews.dart';
+import 'media_tile.dart';
+import 'page_layouts.dart';
 
 class AppPage extends StatefulWidget {
   const AppPage({
@@ -245,12 +246,11 @@ class _AppPageState extends State<AppPage> {
 
 class _CarouselDialog extends StatefulWidget {
   const _CarouselDialog({
-    Key? key,
     required this.windowHeight,
     required this.appData,
     required this.windowWidth,
     required this.initialIndex,
-  }) : super(key: key);
+  });
 
   final double windowHeight;
   final AppData appData;
@@ -320,9 +320,8 @@ class _CarouselDialogState extends State<_CarouselDialog> {
 
 class _CustomBackButton extends StatelessWidget {
   const _CustomBackButton({
-    Key? key,
     this.onPressed,
-  }) : super(key: key);
+  });
 
   final Function()? onPressed;
 
@@ -333,7 +332,7 @@ class _CustomBackButton extends StatelessWidget {
         style: IconButton.styleFrom(fixedSize: const Size(40, 40)),
         onPressed: () {
           Navigator.maybePop(context);
-          if (onPressed != null) onPressed!();
+          if (onPressed != null) onPressed!.call();
         },
         icon: const Icon(YaruIcons.go_previous),
       ),

--- a/lib/store_app/common/app_page/app_reviews.dart
+++ b/lib/store_app/common/app_page/app_reviews.dart
@@ -3,12 +3,13 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:intl/intl.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/app_data.dart';
-import 'package:software/store_app/common/border_container.dart';
-import 'package:software/store_app/common/constants.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import '../app_data.dart';
+import '../border_container.dart';
+import '../constants.dart';
 
 class AppReviews extends StatefulWidget {
   const AppReviews({
@@ -135,11 +136,10 @@ class _AppReviewsState extends State<AppReviews> {
 
 class _ReviewDetailsDialog extends StatelessWidget {
   const _ReviewDetailsDialog({
-    Key? key,
     required this.userReviews,
     this.onVote,
     this.onFlag,
-  }) : super(key: key);
+  });
 
   final List<AppReview>? userReviews;
   final Function(AppReview, bool)? onVote;
@@ -255,7 +255,7 @@ class _ReviewPanel extends StatelessWidget {
                   ),
                   onRatingUpdate: (rating) {
                     if (onRatingUpdate != null) {
-                      onRatingUpdate!(rating);
+                      onRatingUpdate!.call(rating);
                     }
                   },
                   ignoreGestures: !appIsInstalled,
@@ -288,7 +288,7 @@ class _ReviewPanel extends StatelessWidget {
                     reviewUser: reviewUser,
                     onRatingUpdate: (rating) {
                       if (onRatingUpdate != null) {
-                        onRatingUpdate!(rating);
+                        onRatingUpdate!.call(rating);
                       }
                     },
                     onReviewSend: onReviewSend,
@@ -499,11 +499,10 @@ class _ReviewsCarousel extends StatelessWidget {
 
 class _RatingHeader extends StatelessWidget {
   const _RatingHeader({
-    Key? key,
     required this.userReview,
     this.onVote,
     this.onFlag,
-  }) : super(key: key);
+  });
 
   final AppReview userReview;
   final Function(AppReview, bool)? onVote;

--- a/lib/store_app/common/app_page/media_tile.dart
+++ b/lib/store_app/common/app_page/media_tile.dart
@@ -16,16 +16,17 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/store_app/common/safe_network_image.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../safe_network_image.dart';
 
 class MediaTile extends StatelessWidget {
   const MediaTile({
-    Key? key,
+    super.key,
     required this.url,
     this.fit = BoxFit.contain,
     required this.onTap,
-  }) : super(key: key);
+  });
 
   final String url;
   final BoxFit fit;

--- a/lib/store_app/common/app_page/page_layouts.dart
+++ b/lib/store_app/common/app_page/page_layouts.dart
@@ -1,8 +1,9 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:software/store_app/common/constants.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../constants.dart';
 
 class PanedPageLayout extends StatelessWidget {
   const PanedPageLayout({

--- a/lib/store_app/common/app_website.dart
+++ b/lib/store_app/common/app_website.dart
@@ -16,20 +16,21 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
+import '../../l10n/l10n.dart';
+
 class AppWebsite extends StatelessWidget {
   const AppWebsite({
-    Key? key,
+    super.key,
     required this.website,
     this.verified,
     this.starredDeveloper = false,
     this.publisherName,
     this.height = 15.0,
     this.onTap,
-  }) : super(key: key);
+  });
 
   final String website;
   final bool? verified;
@@ -40,7 +41,7 @@ class AppWebsite extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var sizedBox = SizedBox(
+    final sizedBox = SizedBox(
       height: height * 2,
       child: Row(
         mainAxisSize: MainAxisSize.min,

--- a/lib/store_app/common/confirmation_dialog.dart
+++ b/lib/store_app/common/confirmation_dialog.dart
@@ -16,18 +16,19 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n/l10n.dart';
 
 class ConfirmationDialog extends StatefulWidget {
   const ConfirmationDialog({
-    Key? key,
+    super.key,
     this.onConfirm,
     required this.iconData,
     this.title,
     this.message,
     this.positiveConfirm = true,
-  }) : super(key: key);
+  });
 
   final Function()? onConfirm;
   final IconData iconData;

--- a/lib/store_app/common/packagekit/package_controls.dart
+++ b/lib/store_app/common/packagekit/package_controls.dart
@@ -16,8 +16,8 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/package_state.dart';
+import '../../../l10n/l10n.dart';
+import '../../../package_state.dart';
 
 class PackageControls extends StatelessWidget {
   const PackageControls({

--- a/lib/store_app/common/packagekit/package_model.dart
+++ b/lib/store_app/common/packagekit/package_model.dart
@@ -19,15 +19,11 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:packagekit/packagekit.dart';
-import 'package:software/package_state.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/store_app/common/app_model.dart';
+import '../../../package_state.dart';
+import '../../../services/package_service.dart';
+import '../app_model.dart';
 
 class PackageModel extends AppModel {
-  final PackageService _service;
-
-  String? _path;
-  String? get path => _path;
 
   PackageModel({
     required PackageService service,
@@ -42,6 +38,10 @@ class PackageModel extends AppModel {
       throw Exception('Either packaged ID or local file path is required');
     }
   }
+  final PackageService _service;
+
+  String? _path;
+  String? get path => _path;
 
   List<String> get screenshotUrls => <String>[];
 

--- a/lib/store_app/common/packagekit/package_page.dart
+++ b/lib/store_app/common/packagekit/package_page.dart
@@ -18,15 +18,16 @@
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/store_app/common/app_data.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/app_page/app_loading_page.dart';
-import 'package:software/store_app/common/app_page/app_page.dart';
-import 'package:software/store_app/common/packagekit/package_controls.dart';
-import 'package:software/store_app/common/packagekit/package_model.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../../services/package_service.dart';
+import '../app_data.dart';
+import '../app_icon.dart';
+import '../app_page/app_loading_page.dart';
+import '../app_page/app_page.dart';
+import 'package_controls.dart';
+import 'package_model.dart';
 
 class PackagePage extends StatefulWidget {
   const PackagePage({
@@ -61,7 +62,7 @@ class PackagePage extends StatefulWidget {
     return Navigator.push(
       context,
       MaterialPageRoute<void>(
-        builder: (BuildContext context) {
+        builder: (context) {
           return PackagePage.create(
             context: context,
             id: id,
@@ -123,8 +124,8 @@ class _PackagePageState extends State<PackagePage> {
             controls: PackageControls(
               isInstalled: model.isInstalled,
               packageState: model.packageState,
-              remove: () => model.remove(),
-              install: () => model.install(),
+              remove: model.remove,
+              install: model.install,
             ),
             onReviewSend: model.sendReview,
             onRatingUpdate: (v) => model.reviewRating = v,

--- a/lib/store_app/common/packagekit/packagekit_filter_button.dart
+++ b/lib/store_app/common/packagekit/packagekit_filter_button.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/packagekit_filter_x.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../../packagekit_filter_x.dart';
 
 class PackageKitFilterButton extends StatelessWidget {
   const PackageKitFilterButton({

--- a/lib/store_app/common/packagekit/packagekit_group_button.dart
+++ b/lib/store_app/common/packagekit/packagekit_group_button.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/packagekit_group_x.dart';
-import 'package:software/store_app/common/packagekit/packagekit_group_utils.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../../packagekit_group_x.dart';
+import 'packagekit_group_utils.dart';
 
 class PackageKitGroupButton extends StatelessWidget {
   const PackageKitGroupButton({

--- a/lib/store_app/common/snap/snap_channel_button.dart
+++ b/lib/store_app/common/snap/snap_channel_button.dart
@@ -20,15 +20,16 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/snap/snap_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import '../constants.dart';
+import 'snap_model.dart';
 
 class SnapChannelPopupButton extends StatelessWidget {
   const SnapChannelPopupButton({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/store_app/common/snap/snap_connections_settings.dart
+++ b/lib/store_app/common/snap/snap_connections_settings.dart
@@ -17,10 +17,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/snap/snap_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import 'snap_model.dart';
 
 class SnapConnectionsSettings extends StatelessWidget {
   const SnapConnectionsSettings({

--- a/lib/store_app/common/snap/snap_controls.dart
+++ b/lib/store_app/common/snap/snap_controls.dart
@@ -17,16 +17,17 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/snap/snap_channel_button.dart';
-import 'package:software/store_app/common/snap/snap_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import 'snap_channel_button.dart';
+import 'snap_model.dart';
 
 class SnapControls extends StatelessWidget {
   const SnapControls({
-    Key? key,
+    super.key,
     this.direction = Axis.horizontal,
-  }) : super(key: key);
+  });
 
   final Axis direction;
 

--- a/lib/store_app/common/snap/snap_model.dart
+++ b/lib/store_app/common/snap/snap_model.dart
@@ -21,11 +21,11 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/services/color_generator.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/common/app_model.dart';
-import 'package:software/store_app/common/utils.dart';
+import '../../../services/color_generator.dart';
+import '../../../services/snap_service.dart';
+import '../../../snapx.dart';
+import '../app_model.dart';
+import '../utils.dart';
 
 class SnapModel extends AppModel {
   SnapModel(
@@ -293,7 +293,7 @@ class SnapModel extends AppModel {
 
   /// Loads the first change in progress for [huskSnapName] from [SnapService]
   Future<void> _loadChange() async =>
-      change = (await _snapService.getSnapChanges(name: huskSnapName));
+      change = await _snapService.getSnapChanges(name: huskSnapName);
 
   Future<Snap?> _findLocalSnap(String huskSnapName) async =>
       _snapService.findLocalSnap(huskSnapName);
@@ -380,12 +380,12 @@ class SnapModel extends AppModel {
   }
 
   Map<String, SnapChannel> _fillSelectableChannels({required Snap? storeSnap}) {
-    Map<String, SnapChannel> selectableChannels = {};
+    final selectableChannels = <String, SnapChannel>{};
     if (storeSnap != null && storeSnap.tracks.isNotEmpty) {
-      for (var track in storeSnap.tracks) {
-        for (var risk in ['stable', 'candidate', 'beta', 'edge']) {
-          var name = '$track/$risk';
-          var channel = storeSnap.channels[name];
+      for (final track in storeSnap.tracks) {
+        for (final risk in ['stable', 'candidate', 'beta', 'edge']) {
+          final name = '$track/$risk';
+          final channel = storeSnap.channels[name];
           final channelName = '$track/$risk';
           if (channel != null) {
             selectableChannels.putIfAbsent(channelName, () => channel);

--- a/lib/store_app/common/snap/snap_page.dart
+++ b/lib/store_app/common/snap/snap_page.dart
@@ -18,17 +18,18 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/store_app/common/app_data.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/app_page/app_loading_page.dart';
-import 'package:software/store_app/common/app_page/app_page.dart';
-import 'package:software/store_app/common/border_container.dart';
-import 'package:software/store_app/common/snap/snap_connections_settings.dart';
-import 'package:software/store_app/common/snap/snap_controls.dart';
-import 'package:software/store_app/common/snap/snap_model.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../../services/snap_service.dart';
+import '../app_data.dart';
+import '../app_icon.dart';
+import '../app_page/app_loading_page.dart';
+import '../app_page/app_page.dart';
+import '../border_container.dart';
+import 'snap_connections_settings.dart';
+import 'snap_controls.dart';
+import 'snap_model.dart';
 
 class SnapPage extends StatefulWidget {
   const SnapPage({super.key});
@@ -50,7 +51,7 @@ class SnapPage extends StatefulWidget {
     return Navigator.push(
       context,
       MaterialPageRoute<void>(
-        builder: (BuildContext context) {
+        builder: (context) {
           return SnapPage.create(
             context: context,
             huskSnapName: snap.name,

--- a/lib/store_app/common/snap/snap_section.dart
+++ b/lib/store_app/common/snap/snap_section.dart
@@ -18,9 +18,10 @@
 // ignore_for_file: constant_identifier_names
 
 import 'package:flutter/widgets.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+
+import '../../../l10n/l10n.dart';
 
 enum SnapSection {
   all,

--- a/lib/store_app/common/snap/snap_section_popup.dart
+++ b/lib/store_app/common/snap/snap_section_popup.dart
@@ -16,9 +16,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/snap/snap_section.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import 'snap_section.dart';
 
 class SnapSectionPopup extends StatelessWidget {
   const SnapSectionPopup({

--- a/lib/store_app/common/snap/snap_sort.dart
+++ b/lib/store_app/common/snap/snap_sort.dart
@@ -15,7 +15,7 @@
  *
  */
 
-import 'package:software/l10n/l10n.dart';
+import '../../../l10n/l10n.dart';
 
 enum SnapSort {
   name,

--- a/lib/store_app/common/snap/snap_sort_popup.dart
+++ b/lib/store_app/common/snap/snap_sort_popup.dart
@@ -16,16 +16,17 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/snap/snap_sort.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../../l10n/l10n.dart';
+import 'snap_sort.dart';
 
 class SnapSortPopup extends StatelessWidget {
   const SnapSortPopup({
-    Key? key,
+    super.key,
     required this.value,
     required this.onSelected,
-  }) : super(key: key);
+  });
   final SnapSort value;
   final void Function(SnapSort value) onSelected;
 

--- a/lib/store_app/common/utils.dart
+++ b/lib/store_app/common/utils.dart
@@ -20,6 +20,6 @@ import 'dart:math';
 String formatBytes(int bytes, int decimals) {
   if (bytes <= 0) return '0 B';
   const suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  var i = (log(bytes) / log(1024)).floor();
+  final i = (log(bytes) / log(1024)).floor();
   return '${(bytes / pow(1024, i)).toStringAsFixed(decimals)} ${suffixes[i]}';
 }

--- a/lib/store_app/explore/color_banner.dart
+++ b/lib/store_app/explore/color_banner.dart
@@ -18,23 +18,24 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/color_generator.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/app_website.dart';
-import 'package:software/store_app/common/snap/snap_model.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../../l10n/l10n.dart';
+import '../../services/color_generator.dart';
+import '../../services/snap_service.dart';
+import '../../snapx.dart';
+import '../common/app_icon.dart';
+import '../common/app_website.dart';
+import '../common/snap/snap_model.dart';
+
 class ColorBanner extends StatefulWidget {
   const ColorBanner({
-    Key? key,
+    super.key,
     required this.snap,
     required this.sectionName,
     required this.onTap,
-  }) : super(key: key);
+  });
 
   final Snap snap;
   final String sectionName;

--- a/lib/store_app/explore/explore_header.dart
+++ b/lib/store_app/explore/explore_header.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/store_app/common/app_format.dart';
-import 'package:software/store_app/common/app_format_popup.dart';
-import 'package:software/store_app/common/snap/snap_section_popup.dart';
-import 'package:software/store_app/explore/explore_model.dart';
+import '../common/app_format.dart';
+import '../common/app_format_popup.dart';
+import '../common/snap/snap_section_popup.dart';
+import 'explore_model.dart';
 
 class ExploreHeader extends StatelessWidget {
   const ExploreHeader({super.key});
@@ -25,8 +25,7 @@ class ExploreHeader extends StatelessWidget {
           children: [
             MultiAppFormatPopup(
               appFormats: model.appFormats,
-              onTap: (value, appFormat) =>
-                  model.handleAppFormat(value, appFormat),
+              onTap: model.handleAppFormat,
             ),
             if (model.appFormats.contains(AppFormat.snap))
               SnapSectionPopup(

--- a/lib/store_app/explore/explore_page.dart
+++ b/lib/store_app/explore/explore_page.dart
@@ -17,21 +17,22 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/store_app/common/snap/snap_section.dart';
-import 'package:software/store_app/explore/explore_header.dart';
-import 'package:software/store_app/explore/explore_model.dart';
-import 'package:software/store_app/explore/offline_page.dart';
-import 'package:software/store_app/explore/search_field.dart';
-import 'package:software/store_app/explore/search_page.dart';
-import 'package:software/store_app/explore/start_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../../l10n/l10n.dart';
+import '../../services/package_service.dart';
+import '../../services/snap_service.dart';
+import '../common/snap/snap_section.dart';
+import 'explore_header.dart';
+import 'explore_model.dart';
+import 'offline_page.dart';
+import 'search_field.dart';
+import 'search_page.dart';
+import 'start_page.dart';
+
 class ExplorePage extends StatefulWidget {
-  const ExplorePage({Key? key}) : super(key: key);
+  const ExplorePage({super.key});
 
   static Widget create(BuildContext context, bool online) {
     if (!online) return const OfflinePage();
@@ -57,7 +58,7 @@ class _ExplorePageState extends State<ExplorePage> {
     super.initState();
     final model = context.read<ExploreModel>();
 
-    for (var section in SnapSection.values) {
+    for (final section in SnapSection.values) {
       model.loadSection(section);
     }
   }
@@ -96,9 +97,9 @@ class _ExplorePageState extends State<ExplorePage> {
 }
 
 class _ErrorPage extends StatelessWidget {
-  final String errorMessage;
 
-  const _ErrorPage({Key? key, required this.errorMessage}) : super(key: key);
+  const _ErrorPage({required this.errorMessage});
+  final String errorMessage;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/store_app/explore/offline_page.dart
+++ b/lib/store_app/explore/offline_page.dart
@@ -16,11 +16,12 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
+import '../../l10n/l10n.dart';
+
 class OfflinePage extends StatelessWidget {
-  const OfflinePage({Key? key}) : super(key: key);
+  const OfflinePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/store_app/explore/search_field.dart
+++ b/lib/store_app/explore/search_field.dart
@@ -18,13 +18,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/common/snap/snap_section.dart';
-import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
+import '../../l10n/l10n.dart';
+import '../common/snap/snap_section.dart';
+import 'explore_model.dart';
+
 class SearchField extends StatefulWidget {
-  const SearchField({Key? key}) : super(key: key);
+  const SearchField({super.key});
 
   @override
   State<SearchField> createState() => _SearchFieldState();

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -20,17 +20,18 @@ import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:provider/provider.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/common/animated_scroll_view_item.dart';
-import 'package:software/store_app/common/app_format.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/packagekit/package_page.dart';
-import 'package:software/store_app/common/snap/snap_page.dart';
-import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n/l10n.dart';
+import '../../snapx.dart';
+import '../common/animated_scroll_view_item.dart';
+import '../common/app_format.dart';
+import '../common/app_icon.dart';
+import '../common/constants.dart';
+import '../common/packagekit/package_page.dart';
+import '../common/snap/snap_page.dart';
+import 'explore_model.dart';
 
 class SearchPage extends StatelessWidget {
   const SearchPage({super.key});
@@ -161,9 +162,8 @@ class _PackageKitSearchPageState extends State<_PackageKitSearchPage> {
 
 class _WaitPage extends StatelessWidget {
   const _WaitPage({
-    Key? key,
     required this.message,
-  }) : super(key: key);
+  });
 
   final String message;
 
@@ -197,9 +197,8 @@ class _WaitPage extends StatelessWidget {
 
 class _NoSearchResultPage extends StatelessWidget {
   const _NoSearchResultPage({
-    Key? key,
     required this.message,
-  }) : super(key: key);
+  });
 
   final String message;
 

--- a/lib/store_app/explore/section_banner.dart
+++ b/lib/store_app/explore/section_banner.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/snap/snap_page.dart';
-import 'package:software/store_app/common/snap/snap_section.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n/l10n.dart';
+import '../../snapx.dart';
+import '../common/app_icon.dart';
+import '../common/snap/snap_page.dart';
+import '../common/snap/snap_section.dart';
 
 class SectionBanner extends StatelessWidget {
   const SectionBanner({

--- a/lib/store_app/explore/section_grid.dart
+++ b/lib/store_app/explore/section_grid.dart
@@ -17,25 +17,26 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/common/animated_scroll_view_item.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/snap/snap_page.dart';
-import 'package:software/store_app/common/snap/snap_section.dart';
-import 'package:software/store_app/explore/explore_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../snapx.dart';
+import '../common/animated_scroll_view_item.dart';
+import '../common/app_icon.dart';
+import '../common/constants.dart';
+import '../common/snap/snap_page.dart';
+import '../common/snap/snap_section.dart';
+import 'explore_model.dart';
 
 class SectionGrid extends StatelessWidget {
   const SectionGrid({
-    Key? key,
+    super.key,
     required this.snapSection,
     this.animateBanners = false,
     this.padding,
     this.initSection = true,
     this.ignoreScrolling = true,
     required this.initialAmount,
-  }) : super(key: key);
+  });
 
   final SnapSection snapSection;
   final bool animateBanners;

--- a/lib/store_app/explore/start_page.dart
+++ b/lib/store_app/explore/start_page.dart
@@ -19,17 +19,18 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/explore/explore_model.dart';
-import 'package:software/store_app/explore/section_banner.dart';
-import 'package:software/store_app/explore/section_grid.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../snapx.dart';
+import 'explore_model.dart';
+import 'section_banner.dart';
+import 'section_grid.dart';
 
 class StartPage extends StatefulWidget {
   const StartPage({
-    Key? key,
+    super.key,
     required this.screenSize,
-  }) : super(key: key);
+  });
 
   final Size screenSize;
 
@@ -84,7 +85,7 @@ class _StartPageState extends State<StartPage> {
       child: Column(
         children: [
           SectionBanner(
-            gradientColors: bannerSection.colors.map((e) => Color(e)).toList(),
+            gradientColors: bannerSection.colors.map(Color.new).toList(),
             snaps: [bannerSnap, bannerSnap2, bannerSnap3],
             section: bannerSection,
           ),

--- a/lib/store_app/my_apps/my_apps_header.dart
+++ b/lib/store_app/my_apps/my_apps_header.dart
@@ -17,11 +17,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/store_app/common/app_format.dart';
-import 'package:software/store_app/common/app_format_popup.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/packagekit/packagekit_filter_button.dart';
-import 'package:software/store_app/my_apps/my_apps_model.dart';
+import '../common/app_format.dart';
+import '../common/app_format_popup.dart';
+import '../common/constants.dart';
+import '../common/packagekit/packagekit_filter_button.dart';
+import 'my_apps_model.dart';
 
 class MyAppsHeader extends StatelessWidget {
   const MyAppsHeader({super.key});
@@ -45,7 +45,7 @@ class MyAppsHeader extends StatelessWidget {
             ),
             if (model.appFormat == AppFormat.packageKit)
               PackageKitFilterButton(
-                onTap: (value, filter) => model.handleFilter(value, filter),
+                onTap: model.handleFilter,
                 filters: model.packageKitFilters,
                 lockInstalled: true,
               ),

--- a/lib/store_app/my_apps/my_apps_model.dart
+++ b/lib/store_app/my_apps/my_apps_model.dart
@@ -20,16 +20,16 @@ import 'dart:async';
 import 'package:packagekit/packagekit.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/store_app/common/app_format.dart';
+import '../../services/package_service.dart';
+import '../../services/snap_service.dart';
+import '../common/app_format.dart';
 
 class MyAppsModel extends SafeChangeNotifier {
-  final PackageService _packageService;
   MyAppsModel(
     this._packageService,
     this._snapService,
   ) : _localSnaps = [];
+  final PackageService _packageService;
 
   StreamSubscription<bool>? _installedSub;
 
@@ -59,7 +59,7 @@ class MyAppsModel extends SafeChangeNotifier {
   @override
   Future<void> dispose() async {
     await _snapChangesSub?.cancel();
-    _installedSub?.cancel();
+    unawaited(_installedSub?.cancel());
 
     super.dispose();
   }

--- a/lib/store_app/my_apps/my_apps_page.dart
+++ b/lib/store_app/my_apps/my_apps_page.dart
@@ -17,23 +17,24 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/store_app/common/app_format.dart';
-import 'package:software/store_app/my_apps/my_apps_header.dart';
-import 'package:software/store_app/my_apps/my_apps_model.dart';
-import 'package:software/store_app/my_apps/my_apps_search_field.dart';
-import 'package:software/store_app/my_apps/my_packages_page.dart';
-import 'package:software/store_app/my_apps/my_snaps_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+
+import '../../l10n/l10n.dart';
+import '../../services/package_service.dart';
+import '../../services/snap_service.dart';
+import '../common/app_format.dart';
+import 'my_apps_header.dart';
+import 'my_apps_model.dart';
+import 'my_apps_search_field.dart';
+import 'my_packages_page.dart';
+import 'my_snaps_page.dart';
 
 class MyAppsPage extends StatelessWidget {
   const MyAppsPage({
-    Key? key,
+    super.key,
     this.onTabTapped,
     this.initalTabIndex = 0,
-  }) : super(key: key);
+  });
 
   final Function(int)? onTabTapped;
   final int initalTabIndex;

--- a/lib/store_app/my_apps/my_apps_search_field.dart
+++ b/lib/store_app/my_apps/my_apps_search_field.dart
@@ -17,8 +17,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+
+import '../../l10n/l10n.dart';
 
 class MyAppSearchField extends StatefulWidget {
   const MyAppSearchField({

--- a/lib/store_app/my_apps/my_packages_page.dart
+++ b/lib/store_app/my_apps/my_packages_page.dart
@@ -17,15 +17,16 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/store_app/common/animated_scroll_view_item.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/packagekit/package_page.dart';
-import 'package:software/store_app/my_apps/my_apps_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../common/animated_scroll_view_item.dart';
+import '../common/app_icon.dart';
+import '../common/constants.dart';
+import '../common/packagekit/package_page.dart';
+import 'my_apps_model.dart';
+
 class MyPackagesPage extends StatefulWidget {
-  const MyPackagesPage({Key? key}) : super(key: key);
+  const MyPackagesPage({super.key});
 
   @override
   State<MyPackagesPage> createState() => _MyPackagesPageState();

--- a/lib/store_app/my_apps/my_snaps_page.dart
+++ b/lib/store_app/my_apps/my_snaps_page.dart
@@ -18,16 +18,17 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/snapx.dart';
-import 'package:software/store_app/common/animated_scroll_view_item.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/snap/snap_page.dart';
-import 'package:software/store_app/my_apps/my_apps_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../../snapx.dart';
+import '../common/animated_scroll_view_item.dart';
+import '../common/app_icon.dart';
+import '../common/constants.dart';
+import '../common/snap/snap_page.dart';
+import 'my_apps_model.dart';
+
 class MySnapsPage extends StatefulWidget {
-  const MySnapsPage({Key? key}) : super(key: key);
+  const MySnapsPage({super.key});
   @override
   State<MySnapsPage> createState() => _MySnapsPageState();
 }

--- a/lib/store_app/settings/repo_dialog.dart
+++ b/lib/store_app/settings/repo_dialog.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/store_app/updates/updates_model.dart';
-import 'package:software/updates_state.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n/l10n.dart';
+import '../../updates_state.dart';
+import '../updates/updates_model.dart';
 
 class RepoDialog extends StatefulWidget {
   // ignore: unused_element
@@ -41,7 +42,7 @@ class _RepoDialogState extends State<RepoDialog> {
                 children: [
                   IconButton(
                     onPressed:
-                        controller.text.isEmpty ? null : () => model.addRepo(),
+                        controller.text.isEmpty ? null : model.addRepo,
                     icon: const Icon(YaruIcons.plus),
                   ),
                   const SizedBox(

--- a/lib/store_app/settings/settings_model.dart
+++ b/lib/store_app/settings/settings_model.dart
@@ -21,6 +21,11 @@ import 'package:safe_change_notifier/safe_change_notifier.dart';
 const repoUrl = 'https://github.com/ubuntu-flutter-community/software';
 
 class SettingsModel extends SafeChangeNotifier {
+  SettingsModel()
+      : appName = '',
+        packageName = '',
+        version = '',
+        buildNumber = '';
   String appName;
 
   String packageName;
@@ -28,11 +33,6 @@ class SettingsModel extends SafeChangeNotifier {
   String version;
 
   String buildNumber;
-  SettingsModel()
-      : appName = '',
-        packageName = '',
-        version = '',
-        buildNumber = '';
 
   Future<void> init() async {
     final packageInfo = await PackageInfo.fromPlatform();

--- a/lib/store_app/settings/settings_page.dart
+++ b/lib/store_app/settings/settings_page.dart
@@ -18,22 +18,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/store_app/common/border_container.dart';
-import 'package:software/store_app/common/message_bar.dart';
-import 'package:software/store_app/settings/repo_dialog.dart';
-import 'package:software/store_app/settings/settings_model.dart';
-import 'package:software/store_app/updates/updates_model.dart';
-import 'package:software/updates_state.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../../l10n/l10n.dart';
+import '../../services/package_service.dart';
+import '../../updates_state.dart';
+import '../common/border_container.dart';
+import '../common/message_bar.dart';
+import '../updates/updates_model.dart';
+import 'repo_dialog.dart';
+import 'settings_model.dart';
+
 class SettingsPage extends StatefulWidget {
-  const SettingsPage({Key? key}) : super(key: key);
+  const SettingsPage({super.key});
 
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(
@@ -185,7 +186,7 @@ class _RepoTileState extends State<RepoTile> {
   @override
   void initState() {
     super.initState();
-    context.read<UpdatesModel>().init(handleError: () => showSnackBar());
+    context.read<UpdatesModel>().init(handleError: showSnackBar);
   }
 
   void showSnackBar() {

--- a/lib/store_app/store_app.dart
+++ b/lib/store_app/store_app.dart
@@ -19,21 +19,21 @@ import 'package:badges/badges.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/store_app/explore/explore_page.dart';
-import 'package:software/store_app/my_apps/my_apps_page.dart';
-import 'package:software/store_app/settings/settings_page.dart';
-import 'package:software/store_app/store_model.dart';
-import 'package:software/store_app/updates/updates_page.dart';
-import 'package:software/updates_state.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../l10n/l10n.dart';
+import '../services/package_service.dart';
+import '../services/snap_service.dart';
+import '../updates_state.dart';
 import 'common/confirmation_dialog.dart';
+import 'explore/explore_page.dart';
+import 'my_apps/my_apps_page.dart';
+import 'settings/settings_page.dart';
+import 'store_model.dart';
+import 'updates/updates_page.dart';
 
 class StoreApp extends StatelessWidget {
   const StoreApp({super.key});

--- a/lib/store_app/store_model.dart
+++ b/lib/store_app/store_model.dart
@@ -20,10 +20,11 @@ import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:software/updates_state.dart';
 import 'package:window_manager/window_manager.dart';
+
+import '../services/package_service.dart';
+import '../services/snap_service.dart';
+import '../updates_state.dart';
 
 class StoreModel extends SafeChangeNotifier implements WindowListener {
   StoreModel(
@@ -58,7 +59,7 @@ class StoreModel extends SafeChangeNotifier implements WindowListener {
 
   Future<void> init({required void Function() onAskForQuit}) async {
     _onAskForQuit = onAskForQuit;
-    windowManager.setPreventClose(true);
+    unawaited(windowManager.setPreventClose(true));
     windowManager.addListener(this);
 
     await _packageService.init();
@@ -66,7 +67,7 @@ class StoreModel extends SafeChangeNotifier implements WindowListener {
     _snapChangesSub = _snapService.snapChangesInserted.listen((_) {
       notifyListeners();
     });
-    initConnectivity();
+    unawaited(initConnectivity());
     _updatesChangedSub = _packageService.updatesChanged.listen((event) {
       notifyListeners();
     });
@@ -88,9 +89,9 @@ class StoreModel extends SafeChangeNotifier implements WindowListener {
   @override
   Future<void> dispose() async {
     await _snapChangesSub?.cancel();
-    _connectivitySub?.cancel();
-    _updatesChangedSub?.cancel();
-    _updatesStateSub?.cancel();
+    unawaited(_connectivitySub?.cancel());
+    unawaited(_updatesChangedSub?.cancel());
+    unawaited(_updatesStateSub?.cancel());
 
     super.dispose();
   }
@@ -131,7 +132,7 @@ class StoreModel extends SafeChangeNotifier implements WindowListener {
       quit();
     } else {
       if (_onAskForQuit != null) {
-        _onAskForQuit!();
+        _onAskForQuit!.call();
       }
     }
   }

--- a/lib/store_app/updates/update_banner.dart
+++ b/lib/store_app/updates/update_banner.dart
@@ -17,11 +17,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:packagekit/packagekit.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/updates/update_dialog.dart';
 import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../common/constants.dart';
+import 'update_dialog.dart';
 
 class UpdateBanner extends StatelessWidget {
   const UpdateBanner({

--- a/lib/store_app/updates/update_dialog.dart
+++ b/lib/store_app/updates/update_dialog.dart
@@ -19,23 +19,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/package_state.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/store_app/common/app_icon.dart';
-import 'package:software/store_app/common/packagekit/package_model.dart';
-import 'package:software/store_app/common/utils.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '../../l10n/l10n.dart';
+import '../../package_state.dart';
+import '../../services/package_service.dart';
+import '../common/app_icon.dart';
+import '../common/packagekit/package_model.dart';
+import '../common/utils.dart';
+
 class UpdateDialog extends StatefulWidget {
   const UpdateDialog({
-    Key? key,
+    super.key,
     required this.id,
     required this.installedId,
-  }) : super(key: key);
+  });
 
   final PackageKitPackageId id;
   final PackageKitPackageId installedId;

--- a/lib/store_app/updates/updates_model.dart
+++ b/lib/store_app/updates/updates_model.dart
@@ -19,12 +19,19 @@ import 'dart:async';
 
 import 'package:packagekit/packagekit.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/updates_state.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:xterm/xterm.dart';
 
+import '../../services/package_service.dart';
+import '../../updates_state.dart';
+
 class UpdatesModel extends SafeChangeNotifier {
+  UpdatesModel(
+    this._service,
+    this._session,
+  )   : _requireRestart = PackageKitRestart.none,
+        _errorMessage = '',
+        _manualRepoName = '';
   final PackageService _service;
   final UbuntuSession _session;
   StreamSubscription<String>? _errorMessageSub;
@@ -40,13 +47,6 @@ class UpdatesModel extends SafeChangeNotifier {
   StreamSubscription<bool>? _updatesChangedSub;
   StreamSubscription<bool>? _selectionChanged;
   StreamSubscription<String>? _terminalOutputSub;
-
-  UpdatesModel(
-    this._service,
-    this._session,
-  )   : _requireRestart = PackageKitRestart.none,
-        _errorMessage = '',
-        _manualRepoName = '';
 
   Future<void> init({required void Function() handleError}) async {
     // Init the model with the last values
@@ -99,7 +99,7 @@ class UpdatesModel extends SafeChangeNotifier {
       terminal.nextLine();
     });
 
-    _service.getInstalledPackages();
+    unawaited(_service.getInstalledPackages());
   }
 
   @override

--- a/lib/store_app/updates/updates_page.dart
+++ b/lib/store_app/updates/updates_page.dart
@@ -20,14 +20,6 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:liquid_progress_indicator/liquid_progress_indicator.dart';
 import 'package:provider/provider.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/package_service.dart';
-import 'package:software/store_app/common/border_container.dart';
-import 'package:software/store_app/common/constants.dart';
-import 'package:software/store_app/common/message_bar.dart';
-import 'package:software/store_app/updates/update_banner.dart';
-import 'package:software/store_app/updates/updates_model.dart';
-import 'package:software/updates_state.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:xdg_icons/xdg_icons.dart';
@@ -35,6 +27,15 @@ import 'package:xterm/ui.dart';
 import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+import '../../l10n/l10n.dart';
+import '../../services/package_service.dart';
+import '../../updates_state.dart';
+import '../common/border_container.dart';
+import '../common/constants.dart';
+import '../common/message_bar.dart';
+import 'update_banner.dart';
+import 'updates_model.dart';
 
 class UpdatesPage extends StatefulWidget {
   const UpdatesPage({super.key});
@@ -60,7 +61,7 @@ class _UpdatesPageState extends State<UpdatesPage> {
   void initState() {
     super.initState();
     final model = context.read<UpdatesModel>();
-    model.init(handleError: () => showSnackBar());
+    model.init(handleError: showSnackBar);
   }
 
   void showSnackBar() {
@@ -211,9 +212,8 @@ class _CheckForUpdatesSplashScreenState
 
 class _UpdatingPage extends StatefulWidget {
   const _UpdatingPage({
-    Key? key,
     required this.hPadding,
-  }) : super(key: key);
+  });
 
   final double hPadding;
 
@@ -300,9 +300,8 @@ class _UpdatingPageState extends State<_UpdatingPage> {
 
 class _UpdatesHeader extends StatelessWidget {
   const _UpdatesHeader({
-    Key? key,
     required this.hPadding,
-  }) : super(key: key);
+  });
 
   final double hPadding;
 
@@ -327,7 +326,7 @@ class _UpdatesHeader extends StatelessWidget {
               onPressed: model.updatesState == UpdatesState.updating ||
                       model.updatesState == UpdatesState.checkingForUpdates
                   ? null
-                  : () => model.refresh(),
+                  : model.refresh,
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -356,17 +355,17 @@ class _UpdatesHeader extends StatelessWidget {
             if (model.updatesState == UpdatesState.noUpdates)
               if (model.requireRestartApp)
                 ElevatedButton(
-                  onPressed: () => model.exitApp(),
+                  onPressed: model.exitApp,
                   child: Text(context.l10n.requireRestartApp),
                 )
               else if (model.requireRestartSession)
                 ElevatedButton(
-                  onPressed: () => model.logout(),
+                  onPressed: model.logout,
                   child: Text(context.l10n.requireRestartSession),
                 )
               else if (model.requireRestartSystem)
                 ElevatedButton(
-                  onPressed: () => model.reboot(),
+                  onPressed: model.reboot,
                   child: Text(context.l10n.requireRestartSystem),
                 )
           ],
@@ -487,9 +486,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
 }
 
 class _NoUpdatesPage extends StatelessWidget {
-  const _NoUpdatesPage({
-    Key? key,
-  }) : super(key: key);
+  const _NoUpdatesPage();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/updates_state.dart
+++ b/lib/updates_state.dart
@@ -15,7 +15,7 @@
  *
  */
 
-import 'package:software/l10n/l10n.dart';
+import 'l10n/l10n.dart';
 
 enum UpdatesState {
   noUpdates,

--- a/test/services/package_service_test.dart
+++ b/test/services/package_service_test.dart
@@ -44,10 +44,10 @@ void main() {
     final controller = StreamController<PackageKitEvent>.broadcast();
     when(() => transaction.events).thenAnswer((_) => controller.stream);
 
-    when(() => transaction.getRepositoryList())
+    when(transaction.getRepositoryList)
         .thenAnswer((_) => emitFinishedEvent(controller));
 
-    when(() => transaction.refreshCache())
+    when(transaction.refreshCache)
         .thenAnswer((_) => emitFinishedEvent(controller));
 
     when(() => transaction.getUpdates(filter: {}))
@@ -300,10 +300,12 @@ void main() {
     final service = PackageService();
     expect(service.updates, isEmpty);
 
-    expectLater(
-      service.updatesState,
-      emitsInOrder(
-        [UpdatesState.checkingForUpdates, UpdatesState.noUpdates],
+    unawaited(
+      expectLater(
+        service.updatesState,
+        emitsInOrder(
+          [UpdatesState.checkingForUpdates, UpdatesState.noUpdates],
+        ),
       ),
     );
 
@@ -368,7 +370,7 @@ void main() {
   test('toggle repo', () async {
     final service = PackageService();
 
-    expectLater(service.reposChanged, emitsInOrder([true, true]));
+    unawaited(expectLater(service.reposChanged, emitsInOrder([true, true])));
 
     await service.toggleRepo(id: 'myrepository', value: true);
     await service.toggleRepo(id: 'myotherrepository', value: false);

--- a/test/services/snap_service_test.dart
+++ b/test/services/snap_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -188,7 +190,9 @@ void main() {
     when(() => mockSnapdClient.getSnap(snap1.name))
         .thenAnswer((_) async => snap1);
 
-    expectLater(service.snapChangesInserted, emitsInOrder([true, true]));
+    unawaited(
+      expectLater(service.snapChangesInserted, emitsInOrder([true, true])),
+    );
     const channel = 'latest/stable';
     snap = await service.install(snap1, channel, '');
     expect(snap, equals(snap1));
@@ -223,7 +227,9 @@ void main() {
     when(() => mockSnapdClient.getSnap(snap1.name))
         .thenAnswer((_) async => snap1);
 
-    expectLater(service.snapChangesInserted, emitsInOrder([true, true]));
+    unawaited(
+      expectLater(service.snapChangesInserted, emitsInOrder([true, true])),
+    );
     final snap = await service.remove(snap1, '');
     expect(snap, equals(snap1));
     verify(() => mockSnapdClient.remove(snap1.name)).called(1);
@@ -274,7 +280,9 @@ void main() {
     when(() => mockSnapdClient.getSnap(snap1.name))
         .thenAnswer((_) async => snap1);
 
-    expectLater(service.snapChangesInserted, emitsInOrder([true, true]));
+    unawaited(
+      expectLater(service.snapChangesInserted, emitsInOrder([true, true])),
+    );
     const channel = 'latest/stable';
     snap = await service.refresh(
       snap: snap1,


### PR DESCRIPTION
I just ran `dart fix --apply`.
The only manual fix I did, is add `.call()` invocations on nullable, and replace `await` by `unawaited()` (only to the ones added by `dart fix`).

Fixes #568