### PR TITLE
Migrate away from YaruBanner.thirdTitle

### DIFF
--- a/lib/store_app/explore/color_banner.dart
+++ b/lib/store_app/explore/color_banner.dart
@@ -85,16 +85,23 @@ class _ColorBannerState extends State<ColorBanner> {
             .copyWith(fontWeight: FontWeight.w300),
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: Text(widget.sectionName),
-      surfaceTintColor: model.surfaceTintColor,
-      thirdTitle: AppWebsite(
-        height: 14,
-        website:
-            widget.snap.website ?? widget.snap.publisher?.displayName ?? '',
-        verified: model.verified,
-        starredDeveloper: model.starredDeveloper,
-        publisherName: widget.snap.publisher?.displayName ?? widget.snap.name,
+      subtitle: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(widget.sectionName),
+          AppWebsite(
+            height: 14,
+            website:
+                widget.snap.website ?? widget.snap.publisher?.displayName ?? '',
+            verified: model.verified,
+            starredDeveloper: model.starredDeveloper,
+            publisherName:
+                widget.snap.publisher?.displayName ?? widget.snap.name,
+          ),
+        ],
       ),
+      surfaceTintColor: model.surfaceTintColor,
       onTap: widget.onTap,
       iconPadding: const EdgeInsets.only(left: 20, right: 10),
       icon: AppIcon(

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -262,36 +262,44 @@ class _CombinedSearchPage extends StatelessWidget {
                       e.key,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    subtitle: Text(
-                      e.value.snap?.summary ?? e.value.packageId?.version ?? '',
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    thirdTitle: Padding(
-                      padding: const EdgeInsets.only(top: 8),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          RatingBar.builder(
-                            initialRating: e.value.rating ?? 0,
-                            minRating: 1,
-                            direction: Axis.horizontal,
-                            allowHalfRating: true,
-                            itemCount: 5,
-                            itemPadding: EdgeInsets.zero,
-                            itemSize: 20,
-                            itemBuilder: (context, _) => Icon(
-                              YaruIcons.star_filled,
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onSurface
-                                  .withOpacity(0.7),
-                            ),
-                            onRatingUpdate: (rating) {},
-                            ignoreGestures: true,
+                    subtitle: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          e.value.snap?.summary ??
+                              e.value.packageId?.version ??
+                              '',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              RatingBar.builder(
+                                initialRating: e.value.rating ?? 0,
+                                minRating: 1,
+                                direction: Axis.horizontal,
+                                allowHalfRating: true,
+                                itemCount: 5,
+                                itemPadding: EdgeInsets.zero,
+                                itemSize: 20,
+                                itemBuilder: (context, _) => Icon(
+                                  YaruIcons.star_filled,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.7),
+                                ),
+                                onRatingUpdate: (rating) {},
+                                ignoreGestures: true,
+                              ),
+                              _PackageIndicator(appFinding: e.value),
+                            ],
                           ),
-                          _PackageIndicator(appFinding: e.value),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                     icon: AppIcon(
                       iconUrl: e.value.snap?.iconUrl,


### PR DESCRIPTION
The same can be done with a `Column` as a subtitle. This is marginally more code here but helps us to generalize the `YaruBanner` layout.