### PR TITLE
Revert "Adapt to latest yaru_widgets changes"

### DIFF
--- a/lib/store_app/common/app_page/app_page.dart
+++ b/lib/store_app/common/app_page/app_page.dart
@@ -295,7 +295,7 @@ class _CarouselDialogState extends State<_CarouselDialog> {
       },
       child: SimpleDialog(
         title: const YaruCloseButton(
-          alignment: Alignment.centerRight,
+          alignement: Alignment.centerRight,
         ),
         contentPadding: const EdgeInsets.only(bottom: 20),
         titlePadding: const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 6.0),

--- a/lib/store_app/common/loading_banner_grid.dart
+++ b/lib/store_app/common/loading_banner_grid.dart
@@ -42,11 +42,11 @@ class LoadingBannerGrid extends StatelessWidget {
         return Shimmer.fromColors(
           baseColor: shimmerBase,
           highlightColor: shimmerHighLight,
-          child: YaruBanner.tile(
-            title: const Text(
+          child: const YaruBanner(
+            title: Text(
               '',
             ),
-            icon: const Padding(
+            icon: Padding(
               padding: kIconPadding,
               child: AppIcon(
                 iconUrl: null,

--- a/lib/store_app/explore/color_banner.dart
+++ b/lib/store_app/explore/color_banner.dart
@@ -75,46 +75,42 @@ class _ColorBannerState extends State<ColorBanner> {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<SnapModel>();
-    return YaruWatermark(
-      watermark: AppIcon(
+    return YaruBanner(
+      copyIconAsWatermark: true,
+      title: Text(
+        widget.snap.name,
+        style: Theme.of(context)
+            .textTheme
+            .headline4!
+            .copyWith(fontWeight: FontWeight.w300),
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(widget.sectionName),
+          AppWebsite(
+            height: 14,
+            website:
+                widget.snap.website ?? widget.snap.publisher?.displayName ?? '',
+            verified: model.verified,
+            starredDeveloper: model.starredDeveloper,
+            publisherName:
+                widget.snap.publisher?.displayName ?? widget.snap.name,
+          ),
+        ],
+      ),
+      surfaceTintColor: model.surfaceTintColor,
+      onTap: widget.onTap,
+      iconPadding: const EdgeInsets.only(left: 20, right: 10),
+      icon: AppIcon(
+        iconUrl: widget.snap.iconUrl,
+        size: 80,
+      ),
+      watermarkIcon: AppIcon(
         iconUrl: widget.snap.iconUrl,
         size: 130,
-      ),
-      child: YaruBanner.tile(
-        title: Text(
-          widget.snap.name,
-          style: Theme.of(context)
-              .textTheme
-              .headline4!
-              .copyWith(fontWeight: FontWeight.w300),
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(widget.sectionName),
-            AppWebsite(
-              height: 14,
-              website: widget.snap.website ??
-                  widget.snap.publisher?.displayName ??
-                  '',
-              verified: model.verified,
-              starredDeveloper: model.starredDeveloper,
-              publisherName:
-                  widget.snap.publisher?.displayName ?? widget.snap.name,
-            ),
-          ],
-        ),
-        surfaceTintColor: model.surfaceTintColor,
-        onTap: widget.onTap,
-        icon: Padding(
-          padding: const EdgeInsets.only(left: 20, right: 10),
-          child: AppIcon(
-            iconUrl: widget.snap.iconUrl,
-            size: 80,
-          ),
-        ),
       ),
     );
   }

--- a/lib/store_app/explore/search_page.dart
+++ b/lib/store_app/explore/search_page.dart
@@ -57,7 +57,7 @@ class SearchPage extends StatelessWidget {
                   var showSnap = model.appFormats.contains(AppFormat.snap);
                   var showPackageKit =
                       model.appFormats.contains(AppFormat.packageKit);
-                  return YaruBanner.tile(
+                  return YaruBanner(
                     title: Text(
                       appFinding.key,
                       overflow: TextOverflow.ellipsis,
@@ -67,14 +67,12 @@ class SearchPage extends StatelessWidget {
                       showSnap: showSnap,
                       showPackageKit: showPackageKit,
                     ),
-                    icon: Padding(
-                      padding:
-                          const EdgeInsets.only(left: 10, right: 5, bottom: 30),
-                      child: AppIcon(
-                        iconUrl: appFinding.value.snap?.iconUrl ??
-                            appFinding.value.appstream?.icon,
-                      ),
+                    icon: AppIcon(
+                      iconUrl: appFinding.value.snap?.iconUrl ??
+                          appFinding.value.appstream?.icon,
                     ),
+                    iconPadding:
+                        const EdgeInsets.only(left: 10, right: 5, bottom: 30),
                     onTap: appFinding.value.snap != null &&
                             appFinding.value.appstream != null &&
                             showSnap &&

--- a/lib/store_app/explore/section_grid.dart
+++ b/lib/store_app/explore/section_grid.dart
@@ -60,7 +60,7 @@ class SectionGrid extends StatelessWidget {
       itemBuilder: (context, index) {
         final snap = sections.take(initialAmount).elementAt(index);
 
-        final banner = YaruBanner.tile(
+        final banner = YaruBanner(
           title: Text(snap.name),
           subtitle: Text(
             snap.summary,

--- a/lib/store_app/my_apps/my_packages_page.dart
+++ b/lib/store_app/my_apps/my_packages_page.dart
@@ -66,15 +66,13 @@ class _MyPackagesPageState extends State<MyPackagesPage> {
             itemBuilder: (context, index) {
               final package = installedApps[index];
               return AnimatedScrollViewItem(
-                child: YaruBanner.tile(
+                child: YaruBanner(
                   title: Text(package.name),
                   subtitle: Text(package.version),
                   onTap: () => PackagePage.push(context, id: package),
-                  icon: const Padding(
-                    padding: EdgeInsets.only(left: 10, right: 5),
-                    child: AppIcon(
-                      iconUrl: null,
-                    ),
+                  iconPadding: const EdgeInsets.only(left: 10, right: 5),
+                  icon: const AppIcon(
+                    iconUrl: null,
                   ),
                 ),
               );

--- a/lib/store_app/my_apps/my_snaps_page.dart
+++ b/lib/store_app/my_apps/my_snaps_page.dart
@@ -95,7 +95,7 @@ class _MySnapsGrid extends StatelessWidget {
       itemCount: snaps.length,
       itemBuilder: (context, index) {
         final snap = snaps.elementAt(index);
-        return YaruBanner.tile(
+        return YaruBanner(
           title: Text(
             snap.name,
             overflow: TextOverflow.ellipsis,

--- a/lib/store_app/store_app.dart
+++ b/lib/store_app/store_app.dart
@@ -180,7 +180,7 @@ class __AppState extends State<_App> {
     ];
 
     return _initialized
-        ? YaruNavigationPage(
+        ? YaruCompactLayout(
             length: pageItems.length,
             itemBuilder: (context, index, selected) => YaruNavigationRailItem(
               icon: pageItems[index].iconBuilder(context, selected),
@@ -273,7 +273,7 @@ class _CloseWindowConfirmDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return SimpleDialog(
       title: const YaruCloseButton(
-        alignment: Alignment.centerRight,
+        alignement: Alignment.centerRight,
       ),
       titlePadding: const EdgeInsets.fromLTRB(6.0, 6.0, 6.0, 0.0),
       contentPadding: EdgeInsets.zero,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,10 +47,7 @@ dependencies:
   yaru: ^0.4.4
   yaru_colors: ^0.1.1
   yaru_icons: ^0.2.7
-  yaru_widgets: # ^2.0.0-beta-3
-    git:
-      url: https://github.com/ubuntu/yaru_widgets.dart.git
-      ref: 19a69a8faf602248469409d5b1574169917844e5
+  yaru_widgets: ^2.0.0-beta-2
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
Reverts ubuntu-flutter-community/software#596
![grafik](https://user-images.githubusercontent.com/15329494/205289781-34465896-149d-4072-8e9c-094bda67d48d.png)

- wrong bg color of yaru banners
- stretched app icons
- overflowing third title

Sorry @jpnurmi I should have checked out and tested. Can you try again or would this be more effort than to just create a PR with fixes?