### PR TITLE
Band-aid fix for 22.10: disable appstream search by default

### DIFF
--- a/lib/store_app/explore/explore_model.dart
+++ b/lib/store_app/explore/explore_model.dart
@@ -169,7 +169,12 @@ class ExploreModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  final Set<AppFormat> _appFormats = {AppFormat.snap, AppFormat.packageKit};
+  // TODO: appstream search does not work in 22.10
+  // Thus disabling it by default until this is fixed
+  // https://github.com/ubuntu-flutter-community/software/issues/598
+  final Set<AppFormat> _appFormats = {
+    AppFormat.snap,
+  };
   Set<AppFormat> get appFormats => _appFormats;
   void handleAppFormat(AppFormat appFormat) {
     if (!_appFormats.contains(appFormat)) {


### PR DESCRIPTION
Ref #598 