### PR TITLE
ExplorePage: use select() to avoid excessive rebuilds

### DIFF
--- a/lib/store_app/explore/explore_page.dart
+++ b/lib/store_app/explore/explore_page.dart
@@ -66,9 +66,10 @@ class _ExplorePageState extends State<ExplorePage> {
 
   @override
   Widget build(BuildContext context) {
-    final model = context.watch<ExploreModel>();
-
     final screenSize = MediaQuery.of(context).size;
+    final errorMessage = context.select((ExploreModel m) => m.errorMessage);
+    final showErrorPage = context.select((ExploreModel m) => m.showErrorPage);
+    final showSearchPage = context.select((ExploreModel m) => m.showSearchPage);
 
     return Navigator(
       pages: [
@@ -81,9 +82,9 @@ class _ExplorePageState extends State<ExplorePage> {
               children: [
                 const ExploreHeader(),
                 Expanded(
-                  child: model.showErrorPage
-                      ? _ErrorPage(errorMessage: model.errorMessage!)
-                      : model.showSearchPage
+                  child: showErrorPage
+                      ? _ErrorPage(errorMessage: errorMessage!)
+                      : showSearchPage
                           ? const SearchPage()
                           : StartPage(screenSize: screenSize),
                 )


### PR DESCRIPTION
This fixes the issue that the whole ExplorePage was built ~20 times on startup. ExplorePage doesn't care about all the snap-related changes that ExploreModel notifies of most of the time.

Ref: #609