### PR TITLE
app: do not add a global key

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -210,7 +210,6 @@ class __AppState extends State<_App> {
 
     return _initialized
         ? YaruNavigationPage(
-            key: GlobalKey(),
             length: pageItems.length,
             initialIndex: _initialIndex,
             itemBuilder: (context, index, selected) => YaruNavigationRailItem(

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -210,6 +210,7 @@ class __AppState extends State<_App> {
 
     return _initialized
         ? YaruNavigationPage(
+            key: ValueKey(path),
             length: pageItems.length,
             initialIndex: _initialIndex,
             itemBuilder: (context, index, selected) => YaruNavigationRailItem(


### PR DESCRIPTION
Otherwise the app is rebuild from the very start on every build (it always returns to explore page and then re-renders 3-5 times)

@d-loose was the key important for the packageinstaller page?