### PR TITLE
Added network-manager plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,7 @@ apps:
       - desktop
       - desktop-legacy
       - network
+      - network-manager
       - network-manager-observe
       - opengl
       - packagekit-control


### PR DESCRIPTION
Added network-manager plug, not needed to autoconnect but necessary for systems running network-manager as a snap.  Fixes #620