### PR TITLE
Handle absence of PackageKit more gracefully in the UI

### DIFF
--- a/lib/app/common/app_format_popup.dart
+++ b/lib/app/common/app_format_popup.dart
@@ -55,11 +55,13 @@ class AppFormatPopup extends StatelessWidget {
 class MultiAppFormatPopup extends StatelessWidget {
   const MultiAppFormatPopup({
     super.key,
-    required this.appFormats,
+    required this.selectedAppFormats,
+    required this.enabledAppFormats,
     required this.onTap,
   });
 
-  final Set<AppFormat> appFormats;
+  final Set<AppFormat> selectedAppFormats;
+  final Set<AppFormat> enabledAppFormats;
   final Function(AppFormat appFormat) onTap;
 
   @override
@@ -69,11 +71,11 @@ class MultiAppFormatPopup extends StatelessWidget {
       onSelected: (v) => onTap(v),
       itemBuilder: (context) {
         return [
-          for (final appFormat in AppFormat.values)
+          for (final appFormat in enabledAppFormats)
             YaruCheckedPopupMenuItem<AppFormat>(
               padding: EdgeInsets.zero,
               value: appFormat,
-              checked: appFormats.contains(appFormat),
+              checked: selectedAppFormats.contains(appFormat),
               child: Text(
                 appFormat.localize(context.l10n),
               ),
@@ -81,9 +83,9 @@ class MultiAppFormatPopup extends StatelessWidget {
         ];
       },
       child: Text(
-        appFormats.length == AppFormat.values.length
+        selectedAppFormats.length == AppFormat.values.length
             ? context.l10n.allPackageTypes
-            : appFormats.first.localize(context.l10n),
+            : selectedAppFormats.first.localize(context.l10n),
       ),
     );
   }

--- a/lib/app/common/app_format_popup.dart
+++ b/lib/app/common/app_format_popup.dart
@@ -25,10 +25,12 @@ class AppFormatPopup extends StatelessWidget {
     super.key,
     required this.onSelected,
     required this.appFormat,
+    required this.enabledAppFormats,
   });
 
   final void Function(AppFormat appFormat) onSelected;
   final AppFormat appFormat;
+  final Set<AppFormat> enabledAppFormats;
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +38,7 @@ class AppFormatPopup extends StatelessWidget {
       initialValue: appFormat,
       tooltip: context.l10n.appFormat,
       itemBuilder: (v) => [
-        for (var appFormat in AppFormat.values)
+        for (var appFormat in enabledAppFormats)
           PopupMenuItem(
             value: appFormat,
             onTap: () => onSelected(appFormat),

--- a/lib/app/explore/explore_header.dart
+++ b/lib/app/explore/explore_header.dart
@@ -24,10 +24,11 @@ class ExploreHeader extends StatelessWidget {
           runSpacing: 10,
           children: [
             MultiAppFormatPopup(
-              appFormats: model.appFormats,
+              selectedAppFormats: model.selectedAppFormats,
+              enabledAppFormats: model.enabledAppFormats,
               onTap: (appFormat) => model.handleAppFormat(appFormat),
             ),
-            if (model.appFormats.contains(AppFormat.snap))
+            if (model.selectedAppFormats.contains(AppFormat.snap))
               SnapSectionPopup(
                 value: model.selectedSection,
                 onSelected: (v) => model.selectedSection = v,

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -41,10 +41,16 @@ class ExploreModel extends SafeChangeNotifier {
   Future<void> init() async {
     _sectionsChangedSub =
         _snapService.sectionsChanged.listen((_) => notifyListeners());
-    _updatesState = _packageService.lastUpdatesState;
-    _updatesStateSub = _packageService.updatesState.listen((event) {
-      updatesState = event;
-    });
+    if (_packageService.isAvailable) {
+      _updatesState = _packageService.lastUpdatesState;
+      _updatesStateSub = _packageService.updatesState.listen((event) {
+        updatesState = event;
+      });
+    }
+    _appFormats = {
+      AppFormat.snap,
+      if (_packageService.isAvailable) AppFormat.packageKit,
+    };
   }
 
   @override
@@ -169,10 +175,7 @@ class ExploreModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  final Set<AppFormat> _appFormats = {
-    AppFormat.snap,
-    AppFormat.packageKit,
-  };
+  late final Set<AppFormat> _appFormats;
   Set<AppFormat> get appFormats => _appFormats;
   void handleAppFormat(AppFormat appFormat) {
     if (!_appFormats.contains(appFormat)) {

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -178,7 +178,7 @@ class ExploreModel extends SafeChangeNotifier {
   late final Set<AppFormat> _selectedAppFormats;
   Set<AppFormat> get selectedAppFormats => _selectedAppFormats;
   final Set<AppFormat> _enabledAppFormats = {};
-  Set<AppFormat> get enabledAppFormats => _selectedAppFormats;
+  Set<AppFormat> get enabledAppFormats => _enabledAppFormats;
   void handleAppFormat(AppFormat appFormat) {
     if (!_selectedAppFormats.contains(appFormat)) {
       _selectedAppFormats.add(appFormat);

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -47,9 +47,10 @@ class SearchPage extends StatelessWidget {
                 itemCount: snapshot.data!.length,
                 itemBuilder: (context, index) {
                   final appFinding = snapshot.data!.entries.elementAt(index);
-                  var showSnap = model.appFormats.contains(AppFormat.snap);
+                  var showSnap =
+                      model.selectedAppFormats.contains(AppFormat.snap);
                   var showPackageKit =
-                      model.appFormats.contains(AppFormat.packageKit);
+                      model.selectedAppFormats.contains(AppFormat.packageKit);
                   return AppBanner(
                     appFinding: appFinding,
                     showSnap: showSnap,

--- a/lib/app/installed/installed_header.dart
+++ b/lib/app/installed/installed_header.dart
@@ -44,6 +44,7 @@ class InstalledHeader extends StatelessWidget {
           children: [
             AppFormatPopup(
               appFormat: model.appFormat,
+              enabledAppFormats: model.enabledAppFormats,
               onSelected: model.setAppFormat,
             ),
             if (model.appFormat == AppFormat.packageKit)

--- a/lib/app/installed/installed_model.dart
+++ b/lib/app/installed/installed_model.dart
@@ -50,7 +50,9 @@ class InstalledModel extends SafeChangeNotifier {
         _loadLocalSnaps().then((value) => notifyListeners());
       }
     });
+    _enabledAppFormats.add(AppFormat.snap);
     if (_packageService.isAvailable) {
+      _enabledAppFormats.add(AppFormat.packageKit);
       _installedSub = _packageService.installedPackagesChanged.listen((event) {
         notifyListeners();
       });
@@ -86,6 +88,8 @@ class InstalledModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
+  final Set<AppFormat> _enabledAppFormats = {};
+  Set<AppFormat> get enabledAppFormats => _enabledAppFormats;
   AppFormat _appFormat = AppFormat.snap;
   AppFormat get appFormat => _appFormat;
   void setAppFormat(AppFormat value) {

--- a/lib/app/installed/installed_packages_page.dart
+++ b/lib/app/installed/installed_packages_page.dart
@@ -38,7 +38,6 @@ class _InstalledPackagesPageState extends State<InstalledPackagesPage> {
   void initState() {
     super.initState();
     _controller = ScrollController();
-    context.read<InstalledModel>().init();
   }
 
   @override

--- a/lib/app/installed/installed_page.dart
+++ b/lib/app/installed/installed_page.dart
@@ -42,7 +42,7 @@ class InstalledPage extends StatelessWidget {
       create: (context) => InstalledModel(
         getService<PackageService>(),
         getService<SnapService>(),
-      ),
+      )..init(),
       child: const InstalledPage(),
     );
   }

--- a/lib/app/installed/installed_snaps_page.dart
+++ b/lib/app/installed/installed_snaps_page.dart
@@ -32,12 +32,6 @@ class InstalledSnapsPage extends StatefulWidget {
 
 class _InstalledSnapsPageState extends State<InstalledSnapsPage> {
   @override
-  void initState() {
-    context.read<InstalledModel>().init();
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final model = context.watch<InstalledModel>();
     final snaps = model.searchQuery == null

--- a/lib/app/settings/settings_model.dart
+++ b/lib/app/settings/settings_model.dart
@@ -17,6 +17,7 @@
 
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:software/services/packagekit/package_service.dart';
 
 const repoUrl = 'https://github.com/ubuntu-flutter-community/software';
 
@@ -28,11 +29,15 @@ class SettingsModel extends SafeChangeNotifier {
   String version;
 
   String buildNumber;
-  SettingsModel()
+
+  final PackageService _packageService;
+  SettingsModel(this._packageService)
       : appName = '',
         packageName = '',
         version = '',
         buildNumber = '';
+
+  bool get packageKitAvailable => _packageService.isAvailable;
 
   Future<void> init() async {
     final packageInfo = await PackageInfo.fromPlatform();

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -37,7 +37,7 @@ class SettingsPage extends StatefulWidget {
 
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => SettingsModel(),
+      create: (_) => SettingsModel(getService<PackageService>()),
       child: const SettingsPage(),
     );
   }
@@ -69,7 +69,11 @@ class _SettingsPageState extends State<SettingsPage> {
             return BorderContainer(
               childPadding: const EdgeInsets.all(kYaruPagePadding),
               child: Column(
-                children: [_RepoTile.create(context), const _AboutTile()],
+                children: [
+                  if (context.read<SettingsModel>().packageKitAvailable)
+                    _RepoTile.create(context),
+                  const _AboutTile()
+                ],
               ),
             );
           },

--- a/lib/app/updates/updates_page.dart
+++ b/lib/app/updates/updates_page.dart
@@ -5,6 +5,8 @@ import 'package:software/app/common/indeterminate_circular_progress_icon.dart';
 import 'package:software/app/updates/package_updates_page.dart';
 import 'package:software/app/updates/snap_updates_page.dart';
 import 'package:software/l10n/l10n.dart';
+import 'package:software/services/packagekit/package_service.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 class UpdatesPage extends StatefulWidget {
@@ -48,9 +50,10 @@ class UpdatesPage extends StatefulWidget {
 class _UpdatesPageState extends State<UpdatesPage> {
   @override
   Widget build(BuildContext context) {
+    final packageService = getService<PackageService>();
     return DefaultTabController(
       initialIndex: widget.tabIndex,
-      length: 2,
+      length: packageService.isAvailable ? 2 : 1,
       child: Scaffold(
         appBar: AppBar(
           flexibleSpace: TabBar(
@@ -66,19 +69,20 @@ class _UpdatesPageState extends State<UpdatesPage> {
                   label: context.l10n.snapPackages,
                 ),
               ),
-              Tab(
-                icon: _TabChild(
-                  iconData: YaruIcons.debian,
-                  label: context.l10n.debianPackages,
+              if (packageService.isAvailable)
+                Tab(
+                  icon: _TabChild(
+                    iconData: YaruIcons.debian,
+                    label: context.l10n.debianPackages,
+                  ),
                 ),
-              ),
             ],
           ),
         ),
         body: TabBarView(
           children: [
             SnapUpdatesPage.create(context),
-            PackageUpdatesPage.create(context),
+            if (packageService.isAvailable) PackageUpdatesPage.create(context),
           ],
         ),
       ),

--- a/lib/services/packagekit/package_service.dart
+++ b/lib/services/packagekit/package_service.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dbus/dbus.dart';
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
@@ -38,11 +39,19 @@ class MissingPackageIDException implements Exception {
 class PackageService {
   final PackageKitClient _client;
   final NotificationsClient _notificationsClient;
+  bool _serviceAvailable = false;
   PackageService()
       : _client = getService<PackageKitClient>(),
         _notificationsClient = getService<NotificationsClient>() {
-    _client.connect();
+    _client.connect().then((_) {
+      _serviceAvailable = true;
+    }).onError(
+      (_, __) {},
+      test: (error) => error is DBusServiceUnknownException,
+    );
   }
+
+  bool get isAvailable => _serviceAvailable;
 
   final _terminalOutputController = StreamController<String>.broadcast();
   Stream<String> get terminalOutput => _terminalOutputController.stream;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   badges: ^2.0.3
   collection: ^1.16.0
   connectivity_plus: ^2.3.1
+  dbus: ^0.7.8
   desktop_notifications: ^0.6.3
   file: ^6.1.2
   file_selector: ^0.8.4+1


### PR DESCRIPTION
- catch `DBusServiceUnknownException` on `_client.connect()`
(introduces `dbus` dependency, until `PackageKitClient` gets its own exception)
- add an `isAvailable` property to `PackageService`
- hide packageKit specific UI elements if the service isn't available

fix #620 