### PR TITLE
Improve Search/Explore page initialization

### DIFF
--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -49,7 +49,7 @@ class ExploreModel extends SafeChangeNotifier {
     );
 
     if (_packageService.isAvailable) {
-      _appstreamService.init().then((value) {
+      _appstreamService.init().then((_) {
         _enabledAppFormats.add(AppFormat.packageKit);
         _selectedAppFormats.add(AppFormat.packageKit);
         notifyListeners();

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -42,9 +42,11 @@ class ExploreModel extends SafeChangeNotifier {
 
   Future<void> init() async {
     _enabledAppFormats.add(AppFormat.snap);
-    _sectionsChangedSub =
-        _snapService.sectionsChanged.listen((_) => notifyListeners());
     _selectedAppFormats.add(AppFormat.snap);
+    _snapService.initialized.then(
+      (value) => _sectionsChangedSub =
+          _snapService.sectionsChanged.listen((_) => notifyListeners()),
+    );
 
     if (_packageService.isAvailable) {
       _appstreamService.init().then((value) {

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -44,17 +44,19 @@ class ExploreModel extends SafeChangeNotifier {
     _enabledAppFormats.add(AppFormat.snap);
     _sectionsChangedSub =
         _snapService.sectionsChanged.listen((_) => notifyListeners());
+    _selectedAppFormats.add(AppFormat.snap);
+
     if (_packageService.isAvailable) {
-      _enabledAppFormats.add(AppFormat.packageKit);
+      _appstreamService.init().then((value) {
+        _enabledAppFormats.add(AppFormat.packageKit);
+        _selectedAppFormats.add(AppFormat.packageKit);
+        notifyListeners();
+      });
       _updatesState = _packageService.lastUpdatesState;
       _updatesStateSub = _packageService.updatesState.listen((event) {
         updatesState = event;
       });
     }
-    _selectedAppFormats = Set.from(_enabledAppFormats);
-    // Remove classic packages from search until AppStreamService.init is faster
-    // See https://github.com/ubuntu-flutter-community/software/issues/663
-    _selectedAppFormats.remove(AppFormat.packageKit);
   }
 
   @override
@@ -179,7 +181,7 @@ class ExploreModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  late final Set<AppFormat> _selectedAppFormats;
+  final Set<AppFormat> _selectedAppFormats = {};
   Set<AppFormat> get selectedAppFormats => _selectedAppFormats;
   final Set<AppFormat> _enabledAppFormats = {};
   Set<AppFormat> get enabledAppFormats => _enabledAppFormats;

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -29,7 +29,6 @@ class SearchPage extends StatelessWidget {
   const SearchPage({super.key});
 
   @override
-  @override
   Widget build(BuildContext context) {
     final model = context.watch<ExploreModel>();
 

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -78,15 +78,21 @@ class SnapService {
         _snapDClient = getService<SnapdClient>(),
         _notificationsClient = getService<NotificationsClient>();
 
-  Future<void> init() async => authorize().then((_) async {
-        for (var section in SnapSection.values) {
-          try {
-            await _loadSection(section);
-          } on SnapdException catch (e) {
-            throw SnapdException(message: e.message);
-          }
+  late Future<void> _initialized;
+  Future<void> get initialized => _initialized;
+
+  Future<void> init() {
+    _initialized = authorize().then((_) async {
+      for (var section in SnapSection.values) {
+        try {
+          await _loadSection(section);
+        } on SnapdException catch (e) {
+          throw SnapdException(message: e.message);
         }
-      });
+      }
+    });
+    return _initialized;
+  }
 
   Future<void> authorize() async => await _snapDClient.loadAuthorization();
 


### PR DESCRIPTION
* add `AppFormat.packageKit` to enabled and selected formats after `AppStreamService` is done with its initialization
* only subscribe to  `SnapService.sectionsChanged` in `ExploreModel` after `SnapService` is done with its initalization (reduces early page rebuilds)

https://user-images.githubusercontent.com/113362648/210390478-5936c552-d632-41bd-9711-ef6e19c53393.mp4

Any suggestions on how to indicate that `AppStreamService` is still loading in the background?

ref #663 