### PR TITLE
SearchPage: rebuild only when necessary

### DIFF
--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -43,10 +43,8 @@ class ExploreModel extends SafeChangeNotifier {
   Future<void> init() async {
     _enabledAppFormats.add(AppFormat.snap);
     _selectedAppFormats.add(AppFormat.snap);
-    _snapService.initialized.then(
-      (value) => _sectionsChangedSub =
-          _snapService.sectionsChanged.listen((_) => notifyListeners()),
-    );
+    _sectionsChangedSub =
+        _snapService.sectionsChanged.listen((_) => notifyListeners());
 
     if (_packageService.isAvailable) {
       _appstreamService.init().then((_) {

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -30,7 +30,14 @@ class SearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = context.watch<ExploreModel>();
+    final model = context.read<ExploreModel>();
+    final showSnap = context.select(
+      (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.snap),
+    );
+    final showPackageKit = context.select(
+      (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.packageKit),
+    );
+    context.select((ExploreModel m) => m.searchQuery);
 
     return FutureBuilder<Map<String, AppFinding>>(
       future: model.search(),
@@ -51,10 +58,6 @@ class SearchPage extends StatelessWidget {
                 itemCount: snapshot.data!.length,
                 itemBuilder: (context, index) {
                   final appFinding = snapshot.data!.entries.elementAt(index);
-                  var showSnap =
-                      model.selectedAppFormats.contains(AppFormat.snap);
-                  var showPackageKit =
-                      model.selectedAppFormats.contains(AppFormat.packageKit);
                   return AppBanner(
                     appFinding: appFinding,
                     showSnap: showSnap,


### PR DESCRIPTION
Restore incremental loading of snap sections (revert part of #683) and instead rebuild `SearchPage` only if the search parameters change.

https://user-images.githubusercontent.com/113362648/210746328-518394a7-5088-4a5c-b2d5-6830ebc4e97a.mp4

Fix #663