### PR TITLE
another integration test fix (hopefully the last one)

### DIFF
--- a/integration_test/software_test.dart
+++ b/integration_test/software_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:software/app/common/packagekit/package_page.dart';
 import 'package:software/main.dart' as app;
 import 'package:ubuntu_service/ubuntu_service.dart';
 
@@ -24,6 +25,10 @@ void main() {
       expect(helloExe.existsSync(), isFalse);
       initCustomExpect();
       await app.main([localDeb.absolute.path]);
+      await tester.pumpUntil(
+        find.byWidgetPredicate((widget) => widget is PackagePage),
+        timeout: const Duration(seconds: 80),
+      );
       await tester.pumpAndSettle();
 
       final installButton =

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -126,7 +126,11 @@ class __AppState extends State<_App> {
           },
         ).then((_) => closeConfirmDialogOpen = false);
       },
-    ).then((_) => _initialized = true);
+    ).then((_) {
+      setState(() {
+        _initialized = true;
+      });
+    });
   }
 
   void _commandLineListener(List<String> args) {


### PR DESCRIPTION
* Use `pumpUntil` to make sure a `PackagePage` is rendered, before trying to find any widgets or accessing localization strings through a build context.

I've tried adding some delays in various init methods to try and recreate a situation where we end up not having a `PackagePage` and a proper build context after awaiting `pumpAndSettle` (which is likely the cause of the last failure in the CI), but without success. In any case, using `pumpUntil` should make sure this never happens :crossed_fingers: 

Thanks @jpnurmi!