### PR TITLE
ExplorePage: ensure PackageService is initialized

### DIFF
--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -46,6 +46,7 @@ class ExploreModel extends SafeChangeNotifier {
     _sectionsChangedSub =
         _snapService.sectionsChanged.listen((_) => notifyListeners());
 
+    await _packageService.initialized;
     if (_packageService.isAvailable) {
       _appstreamService.init().then((_) {
         _enabledAppFormats.add(AppFormat.packageKit);

--- a/lib/services/packagekit/package_service.dart
+++ b/lib/services/packagekit/package_service.dart
@@ -43,7 +43,7 @@ class PackageService {
   PackageService()
       : _client = getService<PackageKitClient>(),
         _notificationsClient = getService<NotificationsClient>() {
-    _client.connect().then((_) {
+    _initialized = _client.connect().then((_) {
       _serviceAvailable = true;
     }).onError(
       (_, __) {},
@@ -51,6 +51,8 @@ class PackageService {
     );
   }
 
+  late final Future<void> _initialized;
+  Future<void> get initialized => _initialized;
   bool get isAvailable => _serviceAvailable;
 
   final _terminalOutputController = StreamController<String>.broadcast();


### PR DESCRIPTION
This makes sure debian packages are added as an option to the dropdown once `PackageService` is loaded, if packagekit is available

fix #663 