### PR TITLE
Make text black in light mode and white in dark mode

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -194,7 +194,7 @@ class SearchBannerSubtitle extends StatelessWidget {
               appFinding.appstream?.localizedSummary() ??
               '',
           style: TextStyle(
-            color: light ? Colors.black : Colors.white,
+            color: theme.colorScheme.onSurface,
           ),
           overflow: TextOverflow.ellipsis,
         ),

--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -193,6 +193,9 @@ class SearchBannerSubtitle extends StatelessWidget {
           appFinding.snap?.summary ??
               appFinding.appstream?.localizedSummary() ??
               '',
+          style: TextStyle(
+            color: light ? Colors.black : Colors.white,
+          ),
           overflow: TextOverflow.ellipsis,
         ),
         Padding(


### PR DESCRIPTION
Before:

![Screenshot from 2023-01-07 15-35-08](https://user-images.githubusercontent.com/73116038/211158807-fdef438c-e02f-40c8-9240-bbf23e8f84db.png)

![Screenshot from 2023-01-07 15-35-24](https://user-images.githubusercontent.com/73116038/211158812-4815f996-907d-47a2-931d-1124f9519a6f.png)

After:

![Screenshot from 2023-01-07 15-37-45](https://user-images.githubusercontent.com/73116038/211158827-9f9ccb7d-3666-4958-9910-fc5aa6dd7344.png)

![Screenshot from 2023-01-07 15-37-56](https://user-images.githubusercontent.com/73116038/211158831-40c8415b-45d8-41f2-b29e-195f4ae6f617.png)

@madsrh What do you think about making the description completely white in dark mode to match it to the title colour? Added some screenshots :)

fixes #702 
