### PR TITLE
ExploreHeader: use context.select

### DIFF
--- a/lib/app/explore/explore_header.dart
+++ b/lib/app/explore/explore_header.dart
@@ -11,7 +11,13 @@ class ExploreHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = context.watch<ExploreModel>();
+    final model = context.read<ExploreModel>();
+    final selectedAppFormats =
+        context.select((ExploreModel m) => m.selectedAppFormats);
+    final enabledAppFormats =
+        context.select((ExploreModel m) => m.enabledAppFormats);
+    final selectedSection =
+        context.select((ExploreModel m) => m.selectedSection);
 
     return Padding(
       padding: const EdgeInsets.only(
@@ -29,13 +35,13 @@ class ExploreHeader extends StatelessWidget {
           runSpacing: 10,
           children: [
             MultiAppFormatPopup(
-              selectedAppFormats: model.selectedAppFormats,
-              enabledAppFormats: model.enabledAppFormats,
+              selectedAppFormats: selectedAppFormats,
+              enabledAppFormats: enabledAppFormats,
               onTap: (appFormat) => model.handleAppFormat(appFormat),
             ),
-            if (model.selectedAppFormats.contains(AppFormat.snap))
+            if (selectedAppFormats.contains(AppFormat.snap))
               SnapSectionPopup(
-                value: model.selectedSection,
+                value: selectedSection,
                 onSelected: (v) => model.selectedSection = v,
               ),
 

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -183,9 +183,9 @@ class ExploreModel extends SafeChangeNotifier {
   }
 
   final Set<AppFormat> _selectedAppFormats = {};
-  Set<AppFormat> get selectedAppFormats => _selectedAppFormats;
+  Set<AppFormat> get selectedAppFormats => Set.from(_selectedAppFormats);
   final Set<AppFormat> _enabledAppFormats = {};
-  Set<AppFormat> get enabledAppFormats => _enabledAppFormats;
+  Set<AppFormat> get enabledAppFormats => Set.from(_enabledAppFormats);
   void handleAppFormat(AppFormat appFormat) {
     if (!_selectedAppFormats.contains(appFormat)) {
       _selectedAppFormats.add(appFormat);


### PR DESCRIPTION
Use `context.select` in `ExploreHeader` to reduce unnecessary rebuilds.
Ref #609 