### PR TITLE
Fix update page exceptions

### DIFF
--- a/lib/app/explore/start_page.dart
+++ b/lib/app/explore/start_page.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:snapd/snapd.dart';
+import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
 import 'package:software/app/common/search_field.dart';
 import 'package:software/app/common/snap/snap_section.dart';
@@ -88,6 +89,9 @@ class _StartPageState extends State<StartPage> {
         controller: _controller,
         child: Column(
           children: const [
+            SizedBox(
+              height: kPagePadding - 5,
+            ),
             _LoadingSectionBanner(),
             LoadingBannerGrid(),
           ],

--- a/lib/app/updates/snap_updates_page.dart
+++ b/lib/app/updates/snap_updates_page.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/common/constants.dart';
+import 'package:software/app/updates/no_updates_page.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
@@ -99,6 +100,12 @@ class SnapUpdatesPage extends StatelessWidget {
             ),
             if (model.checkingForUpdates)
               const UpdatesSplashScreen(icon: YaruIcons.snapcraft)
+            else if (snaps.isEmpty)
+              const Expanded(
+                child: Center(
+                  child: NoUpdatesPage(),
+                ),
+              )
             else
               Expanded(
                 child: snapshot.connectionState != ConnectionState.done


### PR DESCRIPTION
Exceptions are induced because the snap list is empty. By returning another page instead of the SnapGrid when there are no snaps to update, the exceptions go away.

https://user-images.githubusercontent.com/73116038/211387089-279a179d-4b10-4cbd-9421-5b99d8132926.mp4

Fixes #719 