### PR TITLE
Improve integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: "stable"
+      - run: sudo apt update
       - run: sudo apt -y install git curl cmake ninja-build make clang libgtk-3-dev pkg-config
       - run: flutter build linux -v
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,5 @@ jobs:
           sudo touch /etc/NetworkManager/conf.d/10-globally-managed-devices.conf
           sudo systemctl restart NetworkManager.service
       - run: sudo cp integration_test/assets/packagekit-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
+      - run: sudo cp integration_test/assets/network-manager-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
       - run: LANG=en_US.UTF-8 xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
       - run: sudo netplan apply
       - run: sudo cp integration_test/assets/packagekit-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
       - run: sudo cp integration_test/assets/network-manager-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
+      - run: sudo cp integration_test/assets/snapd-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
       - run: LANG=en_US.UTF-8 xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,8 @@ jobs:
       - uses: subosito/flutter-action@v2
       - run: sudo apt update
       - run: sudo apt install -y clang cmake libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xvfb
-      - run: |
-          # See https://github.com/cockpit-project/cockpit/issues/8477
-          sudo touch /etc/NetworkManager/conf.d/10-globally-managed-devices.conf
-          sudo systemctl restart NetworkManager.service
+      - run: sudo netplan set renderer=NetworkManager
+      - run: sudo netplan apply
       - run: sudo cp integration_test/assets/packagekit-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
       - run: sudo cp integration_test/assets/network-manager-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
       - run: LANG=en_US.UTF-8 xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - run: sudo apt update
-      - run: sudo apt install -y clang cmake libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xvfb
+      - run: sudo apt install -y clang cmake libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xfce4-notifyd xvfb
       - run: sudo netplan set renderer=NetworkManager
       - run: sudo netplan apply
       - run: sudo cp integration_test/assets/packagekit-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/

--- a/integration_test/assets/network-manager-ci.pkla
+++ b/integration_test/assets/network-manager-ci.pkla
@@ -1,0 +1,4 @@
+[Allow access to network-manager in CI, for use in integration tests in destructive CI environments only]
+Identity=unix-user:*
+Action=org.freedesktop.NetworkManager.*
+ResultAny=yes

--- a/integration_test/assets/snapd-ci.pkla
+++ b/integration_test/assets/snapd-ci.pkla
@@ -1,0 +1,4 @@
+[Allow privileged snapd actions without prompting, for use in integration tests in destructive CI environments only]
+Identity=unix-user:*
+Action=io.snapcraft.snapd.manage
+ResultAny=yes

--- a/integration_test/software_test.dart
+++ b/integration_test/software_test.dart
@@ -3,7 +3,10 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:software/app/common/app_banner.dart';
 import 'package:software/app/common/packagekit/package_page.dart';
+import 'package:software/app/common/search_field.dart';
+import 'package:software/app/explore/start_page.dart';
 import 'package:software/main.dart' as app;
 import 'package:ubuntu_service/ubuntu_service.dart';
 
@@ -16,49 +19,118 @@ void main() {
   tearDown(resetAllServices);
 
   group('Package Installer App', () {
-    testWidgets('Install local deb', (tester) async {
+    testWidgets('Install and remove local deb', (tester) async {
+      final installedFile = File('/usr/bin/hello');
+
       final localDeb =
           File('integration_test/assets/hello_2.10-2ubuntu4_amd64.deb');
       expect(localDeb.existsSync(), isTrue);
 
-      final helloExe = File('/usr/bin/hello');
-      expect(helloExe.existsSync(), isFalse);
       initCustomExpect();
+
       await app.main([localDeb.absolute.path]);
       await tester.pumpUntil(
-        find.byWidgetPredicate((widget) => widget is PackagePage),
+        find.byType(PackagePage),
         timeout: const Duration(seconds: 80),
       );
       await tester.pumpAndSettle();
 
-      final installButton =
-          find.widgetWithText(ElevatedButton, tester.lang.install);
-      expectSync(installButton, findsOneWidget);
-      await tester.tap(installButton);
+      await testInstallPackage(tester, installedFile: installedFile);
+      await testRemovePackage(tester, installedFile: installedFile);
+    });
 
-      final enabledUninstallButton = find.ancestor(
-        of: find.text(tester.lang.remove),
-        matching: find.byWidgetPredicate(
-          (widget) => widget is OutlinedButton && widget.enabled,
-        ),
+    testWidgets('Install and remove snap', (tester) async {
+      final installedFile = File('/snap/bin/hello');
+      const packageName = 'hello';
+
+      initCustomExpect();
+
+      await app.main([]);
+      await tester.pumpUntil(
+        find.byType(StartPage),
+        timeout: const Duration(seconds: 80),
       );
-      await tester.pumpUntil(enabledUninstallButton);
+      await tester.pumpAndSettle();
 
-      final uninstallButton =
-          find.widgetWithText(OutlinedButton, tester.lang.remove);
-
-      expectSync(uninstallButton, findsOneWidget);
-      expectSync(installButton, findsNothing);
-
-      expectSync(helloExe.existsSync(), isTrue);
-
-      await tester.tap(uninstallButton);
-      await tester.pumpUntil(uninstallButton, present: false);
-
-      expect(installButton, findsOneWidget);
-      expect(uninstallButton, findsNothing);
-
-      expect(helloExe.existsSync(), isFalse);
+      await testSearchPackage(tester, packageName: packageName);
+      await testInstallPackage(tester, installedFile: installedFile);
+      await testRemovePackage(tester, installedFile: installedFile);
     });
   });
+}
+
+Future<void> testSearchPackage(
+  WidgetTester tester, {
+  required String packageName,
+}) async {
+  final searchField = find.widgetWithText(SearchField, tester.lang.searchHint);
+  expectSync(searchField, findsOneWidget);
+  await tester.enterText(searchField, packageName);
+  await tester.pumpAndSettle();
+
+  final helloBanner = find.widgetWithText(AppBanner, packageName);
+  expectSync(helloBanner, findsOneWidget);
+
+  await tester.tap(helloBanner);
+  await tester.pumpAndSettle();
+}
+
+Future<void> testInstallPackage(
+  WidgetTester tester, {
+  required File installedFile,
+}) async {
+  expect(installedFile.existsSync(), isFalse);
+
+  final enabledInstallButton = find.ancestor(
+    of: find.text(tester.lang.install),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is ElevatedButton && widget.enabled,
+    ),
+  );
+  final enabledRemoveButton = find.ancestor(
+    of: find.text(tester.lang.remove),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is OutlinedButton && widget.enabled,
+    ),
+  );
+  expectSync(enabledInstallButton, findsOneWidget);
+  expectSync(enabledRemoveButton, findsNothing);
+
+  await tester.tap(enabledInstallButton);
+  await tester.pumpUntil(enabledRemoveButton);
+
+  expectSync(enabledRemoveButton, findsOneWidget);
+  expectSync(enabledInstallButton, findsNothing);
+
+  expectSync(installedFile.existsSync(), isTrue);
+}
+
+Future<void> testRemovePackage(
+  WidgetTester tester, {
+  required File installedFile,
+}) async {
+  expectSync(installedFile.existsSync(), isTrue);
+
+  final enabledInstallButton = find.ancestor(
+    of: find.text(tester.lang.install),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is ElevatedButton && widget.enabled,
+    ),
+  );
+  final enabledRemoveButton = find.ancestor(
+    of: find.text(tester.lang.remove),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is OutlinedButton && widget.enabled,
+    ),
+  );
+  expect(enabledInstallButton, findsNothing);
+  expect(enabledRemoveButton, findsOneWidget);
+
+  await tester.tap(enabledRemoveButton);
+  await tester.pumpUntil(enabledInstallButton);
+
+  expect(enabledInstallButton, findsOneWidget);
+  expect(enabledRemoveButton, findsNothing);
+
+  expect(installedFile.existsSync(), isFalse);
 }


### PR DESCRIPTION
A first step towards a better integration test.

* add a new test that installs and removes the [GNU hello snap](https://snapcraft.io/hello)
* break down tests into smaller pieces with minimal UI/UX assumptions:
  - install package
    * expect file installed by package is not present
    * expect to find no enabled `OutlinedButton` with label `Remove`
    * expect to find a single enabled `ElevatedButton` with label 'Install' and tap it
    * wait until an enabled `OutlinedButton` with label 'Remove' is found
    * expect no enabled `ElevatedButton` with label 'Install' is found
    * expect file installed by package is present
  - remove package
    * expect file installed by package not present
    * expect to find no enabled `ElevatedButton` with label `Install`
    * expect to find a single enabled `OutlinedButton` with label 'Remove' and tap it
    * wait until an enabled `ElevatedButton` with label 'Install' is found
    * expect no `OutlinedButton` with label 'Remove' is found
    * expect file installed by package is not present
  - search package
    * expect to find a `SearchField` with hint 'Search'
    * enter package name and wait until an `AppBanner` with the name is found
    * expect to find exactly one `AppBanner` with that name
* fix CI environment
  - add polkit policies for snapd and network-manager
  - set network-manager as netplan renderer (necessary to make the connectivity plugin work)
  - add xfce4-notifyd to provide `org.freedesktop.Notifications` with minimal dependencies

Ref #734 