### PR TITLE
YaruWindowTitlebar: big layout changes

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -197,6 +197,7 @@ class __AppState extends State<_App> {
 
     return _initialized
         ? YaruMasterDetailPage(
+            layoutDelegate: const YaruMasterFixedPaneDelegate(paneWidth: 220),
             appBar: const YaruWindowTitleBar(
               isClosable: false,
               isMaximizable: false,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -146,13 +146,6 @@ class __AppState extends State<_App> {
   Widget build(BuildContext context) {
     final model = context.watch<AppModel>();
     model.setupNotifications(updatesAvailable: context.l10n.updateAvailable);
-    final width = MediaQuery.of(context).size.width;
-
-    final itemStyle = width > 800 && width < 1200
-        ? YaruNavigationRailStyle.labelled
-        : width > 1200
-            ? YaruNavigationRailStyle.labelledExtended
-            : YaruNavigationRailStyle.compact;
 
     final pageItems = [
       PageItem(
@@ -203,15 +196,20 @@ class __AppState extends State<_App> {
     ];
 
     return _initialized
-        ? YaruNavigationPage(
+        ? YaruMasterDetailPage(
+            appBar: const YaruWindowTitleBar(
+              isClosable: false,
+              isMaximizable: false,
+              isMinimizable: false,
+              isRestorable: false,
+            ),
             key: ValueKey(path),
             length: pageItems.length,
             initialIndex: _initialIndex,
-            itemBuilder: (context, index, selected) => YaruNavigationRailItem(
-              icon: pageItems[index].iconBuilder(context, selected),
-              label: pageItems[index].titleBuilder(context),
+            tileBuilder: (context, index, selected) => YaruMasterTile(
+              leading: pageItems[index].iconBuilder(context, selected),
+              title: pageItems[index].titleBuilder(context),
               // tooltip: pageItems[index].tooltipMessage,
-              style: itemStyle,
             ),
             pageBuilder: (context, index) => pageItems[index].builder(context),
           )

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -15,7 +15,6 @@
  *
  */
 
-import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:software/app/common/app_data.dart';
@@ -27,9 +26,7 @@ import 'package:software/app/common/app_page/app_swipe_gesture.dart';
 import 'package:software/app/common/app_page/media_tile.dart';
 import 'package:software/app/common/app_page/page_layouts.dart';
 import 'package:software/app/common/border_container.dart';
-import 'package:software/app/common/custom_back_button.dart';
 import 'package:software/app/common/safe_network_image.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -54,7 +51,6 @@ class AppPage extends StatefulWidget {
     this.reviewRating,
     this.onVote,
     this.onFlag,
-    this.onFileSelect,
   });
 
   final AppData appData;
@@ -76,7 +72,6 @@ class AppPage extends StatefulWidget {
   final void Function(String)? onReviewUserChanged;
   final Function(AppReview, bool)? onVote;
   final Function(AppReview)? onFlag;
-  final void Function(String path)? onFileSelect;
 
   @override
   State<AppPage> createState() => _AppPageState();
@@ -238,34 +233,12 @@ class _AppPageState extends State<AppPage> {
             : narrowWindowLayout;
 
     return Scaffold(
-      appBar: AppBar(
+      appBar: YaruWindowTitleBar(
         title: Text(widget.appData.title),
         titleSpacing: 0,
-        leading: widget.onFileSelect != null
-            ? Center(
-                child: IconButton(
-                  style: IconButton.styleFrom(fixedSize: const Size(40, 40)),
-                  onPressed: () async {
-                    final path = await openFile(
-                      acceptedTypeGroups: [
-                        XTypeGroup(
-                          label: context.l10n.debianPackages,
-                          extensions: const <String>[
-                            'deb',
-                          ],
-                        )
-                      ],
-                    );
-                    if (null != path && widget.onFileSelect != null) {
-                      widget.onFileSelect!(path.path);
-                    }
-                  },
-                  icon: const Icon(YaruIcons.document_open),
-                ),
-              )
-            : CustomBackButton(
-                onPressed: () => Navigator.pop(context),
-              ),
+        leading: MediaQuery.of(context).size.width < 611
+            ? const YaruBackButton()
+            : null,
       ),
       body: BackGesture(
         child: body,

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -236,9 +236,7 @@ class _AppPageState extends State<AppPage> {
       appBar: YaruWindowTitleBar(
         title: Text(widget.appData.title),
         titleSpacing: 0,
-        leading: MediaQuery.of(context).size.width < 611
-            ? const YaruBackButton()
-            : null,
+        leading: const YaruBackButton(),
       ),
       body: BackGesture(
         child: body,

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -190,15 +190,6 @@ class _PackagePageState extends State<PackagePage> {
     return !initialized
         ? const AppLoadingPage()
         : AppPage(
-            onFileSelect: model.path == null
-                ? null
-                : (path) async {
-                    initialized = false;
-                    model.path = path;
-                    model.packageId = null;
-
-                    await model.init().then((_) => initialized = true);
-                  },
             appData: appData,
             permissionContainer: null,
             icon: AppIcon(

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -65,41 +65,31 @@ class _SearchFieldState extends State<SearchField> {
       focusNode: FocusNode(),
       child: GestureDetector(
         onDoubleTap: onDoubleTap,
-        child: TextField(
-          autofocus: true,
-          controller: _controller,
-          onChanged: widget.onChanged,
-          textInputAction: TextInputAction.send,
-          decoration: InputDecoration(
-            hintText: context.l10n.searchHint,
-            prefixIcon: const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 20.0),
-              child: Icon(
+        child: SizedBox(
+          width: 400,
+          child: TextField(
+            autofocus: true,
+            controller: _controller,
+            onChanged: widget.onChanged,
+            textInputAction: TextInputAction.send,
+            decoration: InputDecoration(
+              hintText: context.l10n.searchHint,
+              prefixIcon: const Icon(
                 YaruIcons.search,
                 size: 20,
               ),
+              prefixIconConstraints: const BoxConstraints(
+                minHeight: 44,
+                minWidth: 40,
+              ),
+              isDense: false,
+              border: const UnderlineInputBorder(
+                borderSide: BorderSide(color: Colors.transparent),
+              ),
+              enabledBorder: const UnderlineInputBorder(
+                borderSide: BorderSide(color: Colors.transparent),
+              ),
             ),
-            prefixIconConstraints: const BoxConstraints(
-              minHeight: 50,
-              minWidth: 40,
-            ),
-            isDense: false,
-            border: const UnderlineInputBorder(),
-            enabledBorder: const UnderlineInputBorder(
-              borderSide: BorderSide(color: Colors.transparent),
-            ),
-            suffixIcon: widget.searchQuery.isNotEmpty
-                ? Padding(
-                    padding: const EdgeInsets.only(right: 12.0),
-                    child: IconButton(
-                      onPressed: () => _clear(),
-                      icon: Icon(
-                        YaruIcons.edit_clear,
-                        color: Theme.of(context).hintColor,
-                      ),
-                    ),
-                  )
-                : null,
           ),
         ),
       ),

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -74,10 +74,12 @@ class _SearchFieldState extends State<SearchField> {
             textInputAction: TextInputAction.send,
             decoration: InputDecoration(
               hintText: context.l10n.searchHint,
-              prefixIcon: const Icon(
-                YaruIcons.search,
-                size: 20,
-              ),
+              prefixIcon: MediaQuery.of(context).size.width < 611
+                  ? null
+                  : const Icon(
+                      YaruIcons.search,
+                      size: 20,
+                    ),
               prefixIconConstraints: const BoxConstraints(
                 minHeight: 44,
                 minWidth: 40,

--- a/lib/app/common/snap/snap_grid.dart
+++ b/lib/app/common/snap/snap_grid.dart
@@ -31,6 +31,9 @@ class SnapGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (snaps.isEmpty) {
+      return const SizedBox.shrink();
+    }
     return GridView.builder(
       padding: kGridPadding,
       gridDelegate: kGridDelegate,

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -27,6 +27,7 @@ import 'package:software/app/common/search_field.dart';
 import 'package:software/app/explore/explore_header.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/l10n/l10n.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class SearchPage extends StatelessWidget {
   const SearchPage({
@@ -76,9 +77,13 @@ class SearchPage extends StatelessWidget {
     );
 
     return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        flexibleSpace: SearchField(
+      appBar: YaruWindowTitleBar(
+        leading: MediaQuery.of(context).size.width < 611
+            ? const YaruBackButton()
+            : null,
+        titleSpacing: 0,
+        centerTitle: false,
+        title: SearchField(
           searchQuery: searchQuery,
           onChanged: setSearchQuery,
         ),

--- a/lib/app/explore/start_page.dart
+++ b/lib/app/explore/start_page.dart
@@ -25,12 +25,12 @@ import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
 import 'package:software/app/common/search_field.dart';
 import 'package:software/app/common/snap/snap_section.dart';
-import 'package:software/app/explore/explore_header.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/app/explore/section_banner.dart';
 import 'package:software/app/explore/section_grid.dart';
 import 'package:software/snapx.dart';
 import 'package:yaru_colors/yaru_colors.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class StartPage extends StatefulWidget {
   const StartPage({
@@ -117,19 +117,20 @@ class _StartPageState extends State<StartPage> {
     );
 
     return Scaffold(
-      appBar: AppBar(
-        flexibleSpace: SearchField(
+      appBar: YaruWindowTitleBar(
+        leading: MediaQuery.of(context).size.width < 611
+            ? const YaruBackButton()
+            : null,
+        titleSpacing: 0,
+        centerTitle: false,
+        title: SearchField(
           searchQuery: searchQuery,
           onChanged: setSearchQuery,
         ),
       ),
-      body: Column(
-        children: [
-          const ExploreHeader(),
-          Expanded(
-            child: page,
-          )
-        ],
+      body: Padding(
+        padding: const EdgeInsets.only(top: 15),
+        child: page,
       ),
     );
   }

--- a/lib/app/installed/installed_page.dart
+++ b/lib/app/installed/installed_page.dart
@@ -31,6 +31,7 @@ import 'package:software/app/installed/installed_packages_page.dart';
 import 'package:software/app/installed/installed_snaps_page.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class InstalledPage extends StatelessWidget {
   const InstalledPage({Key? key}) : super(key: key);
@@ -82,8 +83,13 @@ class InstalledPage extends StatelessWidget {
     );
 
     return Scaffold(
-      appBar: AppBar(
-        flexibleSpace: SearchField(
+      appBar: YaruWindowTitleBar(
+        leading: MediaQuery.of(context).size.width < 611
+            ? const YaruBackButton()
+            : null,
+        titleSpacing: 0,
+        centerTitle: false,
+        title: SearchField(
           searchQuery: searchQuery ?? '',
           onChanged: setSearchQuery,
         ),

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -63,6 +63,7 @@ class _SettingsPageState extends State<SettingsPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: YaruWindowTitleBar(
+        title: Text(context.l10n.settingsPageTitle),
         leading: MediaQuery.of(context).size.width < 611
             ? const YaruBackButton()
             : null,

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -61,17 +61,24 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      children: [
-        const ThemeSection(),
-        YaruSection(
-          margin: const EdgeInsets.all(kYaruPagePadding),
-          //width: kMinSectionWidth,
-          child: Column(
-            children: [_RepoTile.create(context), const _AboutTile()],
-          ),
-        )
-      ],
+    return Scaffold(
+      appBar: YaruWindowTitleBar(
+        leading: MediaQuery.of(context).size.width < 611
+            ? const YaruBackButton()
+            : null,
+      ),
+      body: ListView(
+        children: [
+          const ThemeSection(),
+          YaruSection(
+            margin: const EdgeInsets.all(kYaruPagePadding),
+            //width: kMinSectionWidth,
+            child: Column(
+              children: [_RepoTile.create(context), const _AboutTile()],
+            ),
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/app/updates/updates_page.dart
+++ b/lib/app/updates/updates_page.dart
@@ -117,7 +117,13 @@ class _TabChild extends StatelessWidget {
         const SizedBox(
           width: 10,
         ),
-        Text(label)
+        Expanded(
+          child: Text(
+            label,
+            overflow: TextOverflow.fade,
+            maxLines: 1,
+          ),
+        )
       ],
     );
   }

--- a/lib/app/updates/updates_page.dart
+++ b/lib/app/updates/updates_page.dart
@@ -8,6 +8,7 @@ import 'package:software/l10n/l10n.dart';
 import 'package:software/services/packagekit/package_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class UpdatesPage extends StatefulWidget {
   const UpdatesPage({
@@ -55,8 +56,12 @@ class _UpdatesPageState extends State<UpdatesPage> {
       initialIndex: widget.tabIndex,
       length: packageService.isAvailable ? 2 : 1,
       child: Scaffold(
-        appBar: AppBar(
-          flexibleSpace: TabBar(
+        appBar: YaruWindowTitleBar(
+          titleSpacing: 0,
+          leading: MediaQuery.of(context).size.width < 611
+              ? const YaruBackButton()
+              : null,
+          title: TabBar(
             onTap: (value) {
               if (widget.onTabTapped != null) {
                 widget.onTabTapped!(value);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,10 +28,14 @@ import 'package:software/services/snap_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
   await windowManager.ensureInitialized();
+
+  await YaruWindowTitleBar.ensureInitialized();
+
   windowManager.setPreventClose(false);
 
   registerService<AppstreamService>(AppstreamService.new);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   ubuntu_session: ^0.0.2
   url_launcher: ^6.1.2
   version: ^3.0.2
-  window_manager: 0.2.8
+  window_manager: 0.3.0
   xdg_icons: ^0.0.1
   xterm: ^3.3.0
   yaru: ^0.4.7
@@ -54,7 +54,7 @@ dependencies:
   yaru_widgets:
     git:
       url: https://github.com/ubuntu/yaru_widgets.dart
-      ref: bace5613a9e463b1b3c4b778713ee4859496c2c0
+      ref: 4c6e25ab51c05b659eca0f296f8e0beb157e4657
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
- use yaruwindowtitlebar to save vertical screenspace
- adapt the layout to use yarumasterdetailpage
- add the searchbar to the titlebar
- adapt all pages containing an appbar to use yaruwindowtitlebar

![grafik](https://user-images.githubusercontent.com/15329494/211905366-e76e0bfe-f24d-4a65-ac32-ecfeb8d92328.png)
![grafik](https://user-images.githubusercontent.com/15329494/211905396-62fb1cba-b091-495f-a492-b80cb4f52f2b.png)
![grafik](https://user-images.githubusercontent.com/15329494/211905606-95a7224b-7951-4116-9e2e-e20053e63a14.png)
![grafik](https://user-images.githubusercontent.com/15329494/211905640-57fea286-9a5d-496d-97e1-cb3fcef46c8c.png)

![grafik](https://user-images.githubusercontent.com/15329494/211905126-87b8a078-f334-40cf-8ad7-6afc11871c5d.png)
![grafik](https://user-images.githubusercontent.com/15329494/211905165-15d255b2-8a34-42da-a91e-ab63020bd61e.png)
![grafik](https://user-images.githubusercontent.com/15329494/211905305-d86eaad0-0eaa-4eb9-8c15-729a49244b96.png)
