### PR TITLE
Fix API change: Bring back dialog close buttons

### DIFF
--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -148,7 +148,7 @@ class _ReviewDetailsDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SimpleDialog(
-      title: YaruTitleBar(
+      title: YaruDialogTitleBar(
         title: Text(context.l10n.reviewsAndRatings),
       ),
       titlePadding: EdgeInsets.zero,
@@ -359,7 +359,7 @@ class _MyReviewDialogState extends State<_MyReviewDialog> {
     final theme = Theme.of(context);
     return AlertDialog(
       titlePadding: EdgeInsets.zero,
-      title: YaruTitleBar(
+      title: YaruDialogTitleBar(
         title: Text(context.l10n.yourReview),
         leading: const Icon(YaruIcons.star_filled),
       ),

--- a/lib/app/common/message_bar.dart
+++ b/lib/app/common/message_bar.dart
@@ -18,7 +18,7 @@ class MessageBar extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        YaruTitleBar(
+        YaruDialogTitleBar(
           title: TextButton(
             child: Row(
               mainAxisSize: MainAxisSize.min,

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -257,7 +257,7 @@ class _ShowDepsDialogState extends State<_ShowDepsDialog> {
     return AlertDialog(
       title: SizedBox(
         width: 500,
-        child: YaruTitleBar(
+        child: YaruDialogTitleBar(
           title: Text(context.l10n.dependencies),
         ),
       ),

--- a/lib/app/settings/repo_dialog.dart
+++ b/lib/app/settings/repo_dialog.dart
@@ -34,7 +34,7 @@ class _RepoDialogState extends State<RepoDialog> {
     final model = context.watch<PackageUpdatesModel>();
 
     return SimpleDialog(
-      title: YaruTitleBar(
+      title: YaruDialogTitleBar(
         title: model.updatesState != UpdatesState.updating &&
                 model.updatesState != UpdatesState.checkingForUpdates
             ? Row(

--- a/lib/app/updates/update_dialog.dart
+++ b/lib/app/updates/update_dialog.dart
@@ -195,7 +195,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
       )
     ];
     return SimpleDialog(
-      title: YaruTitleBar(
+      title: YaruDialogTitleBar(
         centerTitle: false,
         title: model.packageState != PackageState.ready
             ? null


### PR DESCRIPTION
This is a  needed fix for the api change of titlebars in yaru widgets to make the **close button** in dialogs return

![grafik](https://user-images.githubusercontent.com/15329494/212184269-e394dfbf-db74-48ca-a10f-74ae19556c05.png)
