### PR TITLE
Update yaru widgets for doubleclick->maximize on the first titlebar

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -198,9 +198,7 @@ class __AppState extends State<_App> {
     return _initialized
         ? YaruMasterDetailPage(
             layoutDelegate: const YaruMasterFixedPaneDelegate(paneWidth: 220),
-            appBar: const YaruWindowTitleBar(
-              style: YaruTitleBarStyle.undecorated,
-            ),
+            appBar: const YaruWindowTitleBar(),
             key: ValueKey(path),
             length: pageItems.length,
             initialIndex: _initialIndex,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -199,10 +199,7 @@ class __AppState extends State<_App> {
         ? YaruMasterDetailPage(
             layoutDelegate: const YaruMasterFixedPaneDelegate(paneWidth: 220),
             appBar: const YaruWindowTitleBar(
-              isClosable: false,
-              isMaximizable: false,
-              isMinimizable: false,
-              isRestorable: false,
+              style: YaruTitleBarStyle.undecorated,
             ),
             key: ValueKey(path),
             length: pageItems.length,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   yaru_widgets:
     git:
       url: https://github.com/ubuntu/yaru_widgets.dart
-      ref: 2bf3ba711f45f8b4bdab6916b406101222078d00
+      ref: b16e8525747e0cc13a28d8553d9f3355ccacdec8
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   yaru_widgets:
     git:
       url: https://github.com/ubuntu/yaru_widgets.dart
-      ref: b23950a134d4d96960823e874ff224f3c308f04e
+      ref: 2bf3ba711f45f8b4bdab6916b406101222078d00
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION

https://user-images.githubusercontent.com/15329494/212406443-a891e0c3-ced2-42b9-bbf9-8f2b53578157.mp4

- left bar has no window controls in landscape layout but has them in portrait layout
- left bar reacts on double click even if undecorated

Fixed in yaru widgets by @jpnurmi 