### PR TITLE
Revert navigation but keep CSD

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -209,7 +209,7 @@ class __AppState extends State<_App> {
         ? YaruNavigationPage(
             leading: AnimatedContainer(
               width: normalWindowSize
-                  ? 110
+                  ? 100
                   : wideWindowSize
                       ? 250
                       : 60,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -195,21 +195,36 @@ class __AppState extends State<_App> {
       ),
     ];
 
+    final width = MediaQuery.of(context).size.width;
+
+    var normalWindowSize = width > 800 && width < 1200;
+    var wideWindowSize = width > 1200;
+    final itemStyle = normalWindowSize
+        ? YaruNavigationRailStyle.labelled
+        : wideWindowSize
+            ? YaruNavigationRailStyle.labelledExtended
+            : YaruNavigationRailStyle.compact;
+
     return _initialized
-        ? YaruMasterDetailPage(
-            layoutDelegate: const YaruMasterFixedPaneDelegate(paneWidth: 220),
-            appBar: const YaruWindowTitleBar(
-              isClosable: false,
-              isMaximizable: false,
-              isMinimizable: false,
-              isRestorable: false,
+        ? YaruNavigationPage(
+            leading: AnimatedContainer(
+              width: normalWindowSize
+                  ? 110
+                  : wideWindowSize
+                      ? 250
+                      : 60,
+              duration: const Duration(milliseconds: 200),
+              child: YaruWindowTitleBar(
+                title: Text(wideWindowSize ? 'Ubuntu Software' : ''),
+                style: YaruTitleBarStyle.undecorated,
+              ),
             ),
             key: ValueKey(path),
             length: pageItems.length,
             initialIndex: _initialIndex,
-            tileBuilder: (context, index, selected) => YaruMasterTile(
-              leading: pageItems[index].iconBuilder(context, selected),
-              title: pageItems[index].titleBuilder(context),
+            itemBuilder: (context, index, selected) => YaruNavigationRailItem(
+              icon: pageItems[index].iconBuilder(context, selected),
+              label: pageItems[index].titleBuilder(context), style: itemStyle,
               // tooltip: pageItems[index].tooltipMessage,
             ),
             pageBuilder: (context, index) => pageItems[index].builder(context),

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -79,12 +79,10 @@ class _SearchFieldState extends State<SearchField> {
               decoration: InputDecoration(
                 filled: true,
                 hintText: context.l10n.searchHint,
-                prefixIcon: MediaQuery.of(context).size.width < 611
-                    ? null
-                    : const Icon(
-                        YaruIcons.search,
-                        size: 15,
-                      ),
+                prefixIcon: const Icon(
+                  YaruIcons.search,
+                  size: 15,
+                ),
                 prefixIconConstraints:
                     const BoxConstraints(minWidth: 40, minHeight: 0),
                 isDense: true,

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -21,10 +21,8 @@ import 'package:software/app/common/app_banner.dart';
 import 'package:software/app/common/app_finding.dart';
 import 'package:software/app/common/app_format.dart';
 import 'package:software/app/common/constants.dart';
-import 'package:software/app/common/custom_back_button.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
 import 'package:software/app/common/search_field.dart';
-
 import 'package:software/app/explore/explore_header.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/l10n/l10n.dart';
@@ -80,9 +78,6 @@ class SearchPage extends StatelessWidget {
 
     return Scaffold(
       appBar: YaruWindowTitleBar(
-        leading: MediaQuery.of(context).size.width < 611
-            ? const CustomBackButton()
-            : null,
         titleSpacing: 0,
         centerTitle: true,
         title: SearchField(

--- a/lib/app/explore/start_page.dart
+++ b/lib/app/explore/start_page.dart
@@ -19,7 +19,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/app/common/custom_back_button.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
 import 'package:software/app/common/search_field.dart';
 import 'package:software/app/common/snap/snap_section.dart';
@@ -81,9 +80,6 @@ class _StartPageState extends State<StartPage> {
 
     return Scaffold(
       appBar: YaruWindowTitleBar(
-        leading: MediaQuery.of(context).size.width < 611
-            ? const CustomBackButton()
-            : null,
         titleSpacing: 0,
         title: SearchField(
           autofocus: false,

--- a/lib/app/installed/installed_page.dart
+++ b/lib/app/installed/installed_page.dart
@@ -18,18 +18,17 @@
 import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/app/common/constants.dart';
-import 'package:software/app/common/custom_back_button.dart';
-import 'package:software/app/common/indeterminate_circular_progress_icon.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/packagekit/package_service.dart';
-import 'package:software/services/snap_service.dart';
 import 'package:software/app/common/app_format.dart';
+import 'package:software/app/common/constants.dart';
+import 'package:software/app/common/indeterminate_circular_progress_icon.dart';
 import 'package:software/app/common/search_field.dart';
 import 'package:software/app/installed/installed_header.dart';
 import 'package:software/app/installed/installed_model.dart';
 import 'package:software/app/installed/installed_packages_page.dart';
 import 'package:software/app/installed/installed_snaps_page.dart';
+import 'package:software/l10n/l10n.dart';
+import 'package:software/services/packagekit/package_service.dart';
+import 'package:software/services/snap_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -85,9 +84,6 @@ class InstalledPage extends StatelessWidget {
 
     return Scaffold(
       appBar: YaruWindowTitleBar(
-        leading: MediaQuery.of(context).size.width < 611
-            ? const CustomBackButton()
-            : null,
         titleSpacing: 0,
         centerTitle: false,
         title: SearchField(

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -19,13 +19,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/app.dart';
-import 'package:software/app/common/custom_back_button.dart';
-import 'package:software/l10n/l10n.dart';
-import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/app/common/message_bar.dart';
 import 'package:software/app/settings/repo_dialog.dart';
 import 'package:software/app/settings/settings_model.dart';
 import 'package:software/app/updates/package_updates_model.dart';
+import 'package:software/l10n/l10n.dart';
+import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/packagekit/updates_state.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
@@ -65,9 +64,6 @@ class _SettingsPageState extends State<SettingsPage> {
     return Scaffold(
       appBar: YaruWindowTitleBar(
         title: Text(context.l10n.settingsPageTitle),
-        leading: MediaQuery.of(context).size.width < 611
-            ? const CustomBackButton()
-            : null,
       ),
       body: ListView(
         children: [

--- a/lib/app/updates/updates_page.dart
+++ b/lib/app/updates/updates_page.dart
@@ -1,7 +1,6 @@
 import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:software/app/common/constants.dart';
-import 'package:software/app/common/custom_back_button.dart';
 import 'package:software/app/common/indeterminate_circular_progress_icon.dart';
 import 'package:software/app/updates/package_updates_page.dart';
 import 'package:software/app/updates/snap_updates_page.dart';
@@ -59,9 +58,6 @@ class _UpdatesPageState extends State<UpdatesPage> {
       child: Scaffold(
         appBar: YaruWindowTitleBar(
           titleSpacing: 0,
-          leading: MediaQuery.of(context).size.width < 611
-              ? const CustomBackButton()
-              : null,
           title: TabBar(
             indicatorPadding: EdgeInsets.zero,
             onTap: (value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   yaru_widgets:
     git:
       url: https://github.com/ubuntu/yaru_widgets.dart
-      ref: b23950a134d4d96960823e874ff224f3c308f04e
+      ref: b16e8525747e0cc13a28d8553d9f3355ccacdec8
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
The client side decorations make this app feel much more at home in Ubuntu with GNOME.

However the master detail navigation currently needs a bit more refinement in yaru_widgets, since #766 occurred for some but most importantly this bug#761.

This reverts the navigation back to how it was but keeps the CSD to make this app feel at home on Ubuntu desktop.

Closes #766 
Closes #761 

But we should re-open those bugs if not present in yaru_widgets

Screenshots 

![grafik](https://user-images.githubusercontent.com/15329494/212465369-e6e3edd8-5d53-430d-916e-bf13676381f7.png)
![grafik](https://user-images.githubusercontent.com/15329494/212465384-3e71d6c8-a489-44be-a787-97cdc4538c7a.png)
![grafik](https://user-images.githubusercontent.com/15329494/212465391-4ffbc9b6-ba0d-4112-a529-4a87a8719240.png)


Recording for the transition animations:


https://user-images.githubusercontent.com/15329494/212465362-4dadf7fd-d5b8-4c12-8f33-80a97bfe4e41.mp4


