### PR TITLE
Release 0.2.6-alpha

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: The Ubuntu Software Store made with Flutter.
 
 publish_to: "none"
 
-version: 0.2.5-alpha
+version: 0.2.6-alpha
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
If we keep the "release" from pubspec as the version in snap-store, we need to figure out a different way to create releases to not create merge conflicts. We could leave out the version in pubspec to be "alpha" and then change the version only for the merge into the other channel to be "0.2....." with a number.

Anyway, keeping the previous release procedure for now until we figured this all out.