### PR TITLE
Show progress indicator when installing/removing deb packages

### DIFF
--- a/lib/app/common/packagekit/package_controls.dart
+++ b/lib/app/common/packagekit/package_controls.dart
@@ -18,6 +18,7 @@
 import 'package:flutter/material.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/packagekit/package_state.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class PackageControls extends StatelessWidget {
   const PackageControls({
@@ -47,26 +48,37 @@ class PackageControls extends StatelessWidget {
       runAlignment: WrapAlignment.start,
       spacing: 10,
       runSpacing: 10,
-      children: [
-        if (isInstalled == true)
-          OutlinedButton(
-            onPressed: packageState != PackageState.ready ? null : remove,
-            child: Text(context.l10n.remove),
-          ),
-        if (isInstalled == false)
-          ElevatedButton(
-            onPressed: packageState != PackageState.ready
-                ? null
-                : (hasDependencies == true ? showDeps : install),
-            child: Text(context.l10n.install),
-          ),
-        if (isInstalled == true && versionChanged == true)
-          ElevatedButton(
-            onPressed: packageState != PackageState.ready ? null : install,
-            child: Text(context.l10n.refresh),
-          ),
-        const SizedBox.shrink()
-      ],
+      children: packageState == PackageState.processing
+          ? [
+              const SizedBox(
+                height: 20,
+                child: YaruCircularProgressIndicator(
+                  strokeWidth: 3,
+                ),
+              ),
+              Text(context.l10n.processing),
+            ]
+          : [
+              if (isInstalled == true)
+                OutlinedButton(
+                  onPressed: packageState != PackageState.ready ? null : remove,
+                  child: Text(context.l10n.remove),
+                ),
+              if (isInstalled == false)
+                ElevatedButton(
+                  onPressed: packageState != PackageState.ready
+                      ? null
+                      : (hasDependencies == true ? showDeps : install),
+                  child: Text(context.l10n.install),
+                ),
+              if (isInstalled == true && versionChanged == true)
+                ElevatedButton(
+                  onPressed:
+                      packageState != PackageState.ready ? null : install,
+                  child: Text(context.l10n.refresh),
+                ),
+              const SizedBox.shrink()
+            ],
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -136,6 +136,7 @@
   "multiAppFormatsFound": "We've found multiple formats for this application.",
   "changingPermissions": "Changing permissions",
   "installing": "Installing",
+  "processing": "Processing",
   "removing": "Removing",
   "refreshing": "Refreshing",
   "attention": "Attention!",


### PR DESCRIPTION
https://user-images.githubusercontent.com/113362648/212661280-9c1232e7-3c10-4b55-ae9e-9ba2736e737f.mp4

Currently `PackageState` has only two states (`processing` and `ready`) - we should probably add more specific states in the future.

fix #783 