### PR TITLE
BasePlate and FallBackIcon improvements

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -82,12 +82,13 @@ class AppBanner extends StatelessWidget {
     var appIcon = Padding(
       padding: const EdgeInsets.only(bottom: 55, right: 5),
       child: SizedBox(
-        height: 45,
-        width: 45,
+        height: 40,
+        width: 40,
         child: BasePlate(
+          childPadding: 5,
           useBorder: true,
           hovered: false,
-          radius: 100,
+          radius: 8,
           child: AppIcon(
             iconUrl: iconUrl,
           ),

--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -19,7 +19,9 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:software/app/common/border_container.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+const _borderColor = Color.fromARGB(255, 189, 189, 189);
 
 class AppIcon extends StatelessWidget {
   const AppIcon({
@@ -37,29 +39,19 @@ class AppIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fallBackIcon = BorderContainer(
-      borderColor: color,
-      containerPadding: EdgeInsets.zero,
-      borderRadius: 200,
+    final fallBackIcon = YaruBorderContainer(
+      border: Border.all(color: _borderColor),
+      borderRadius: BorderRadius.circular(200),
       width: size,
       height: size,
       child: _FallBackIcon(
         size: size,
-        borderColor: borderColor,
-        color: color,
       ),
     );
 
-    final theme = Theme.of(context);
-    var light = theme.brightness == Brightness.light;
-    final shimmerBase = color ??
-        (light
-            ? const Color.fromARGB(120, 228, 228, 228)
-            : const Color.fromARGB(255, 51, 51, 51));
-    final shimmerHighLight = borderColor ??
-        (light
-            ? const Color.fromARGB(200, 247, 247, 247)
-            : const Color.fromARGB(255, 57, 57, 57));
+    final shimmerBase = color ?? (const Color.fromARGB(120, 228, 228, 228));
+    final shimmerHighLight =
+        borderColor ?? (const Color.fromARGB(200, 247, 247, 247));
     final fallBackLoadingIcon = Shimmer.fromColors(
       baseColor: shimmerBase,
       highlightColor: shimmerHighLight,
@@ -93,37 +85,19 @@ class _FallBackIcon extends StatelessWidget {
   const _FallBackIcon({
     Key? key,
     required this.size,
-    this.borderColor,
-    this.color,
   }) : super(key: key);
 
   final double size;
-  final Color? borderColor;
-  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final light = theme.brightness == Brightness.light;
-    final border = BorderSide(
-      color: borderColor ?? (light ? Colors.white : theme.dividerColor),
-      width: light ? 0.5 : 0.3,
+    const border = BorderSide(
+      color: _borderColor,
+      width: 0.5,
     );
-    final shadeMax = color != null
-        ? color!.withOpacity(0.1)
-        : light
-            ? theme.dividerColor.withOpacity(0.1)
-            : theme.colorScheme.onSurface.withOpacity(0.03);
-    final shadeMid = color != null
-        ? color!.withOpacity(0.05)
-        : light
-            ? theme.dividerColor.withOpacity(0.05)
-            : theme.colorScheme.onSurface.withOpacity(0.015);
-    final shadeMin = color != null
-        ? color!.withOpacity(0.005)
-        : light
-            ? theme.dividerColor.withOpacity(0.005)
-            : theme.colorScheme.onSurface.withOpacity(0.005);
+    const shadeMax = Color.fromARGB(255, 199, 199, 199);
+    const shadeMid = Color.fromARGB(255, 214, 214, 214);
+    const shadeMin = Color.fromARGB(255, 236, 236, 236);
     return ClipOval(
       child: FittedBox(
         fit: BoxFit.none,
@@ -135,7 +109,7 @@ class _FallBackIcon extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.all(size),
-                    decoration: BoxDecoration(
+                    decoration: const BoxDecoration(
                       border: Border(
                         right: border,
                       ),
@@ -144,7 +118,7 @@ class _FallBackIcon extends StatelessWidget {
                   ),
                   Container(
                     padding: EdgeInsets.all(size),
-                    decoration: BoxDecoration(
+                    decoration: const BoxDecoration(
                       color: shadeMax,
                       border: Border(
                         top: border,
@@ -158,7 +132,7 @@ class _FallBackIcon extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.all(size * 1.2),
-                    decoration: BoxDecoration(
+                    decoration: const BoxDecoration(
                       color: shadeMin,
                       border: Border(
                         bottom: border,
@@ -167,7 +141,7 @@ class _FallBackIcon extends StatelessWidget {
                   ),
                   Container(
                     padding: EdgeInsets.all(size * 1.2),
-                    decoration: BoxDecoration(color: shadeMid),
+                    decoration: const BoxDecoration(color: shadeMid),
                   ),
                 ],
               ),

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -108,7 +108,7 @@ class _AppPageState extends State<AppPage> {
       child: BasePlate(
         useBorder: true,
         hovered: false,
-        radius: 100,
+        radius: 10,
         child: widget.icon,
       ),
     );

--- a/lib/app/common/base_plate.dart
+++ b/lib/app/common/base_plate.dart
@@ -9,6 +9,7 @@ class BasePlate extends StatelessWidget {
     this.blurRadius = 5,
     this.spreadRadius = 3,
     this.useBorder = false,
+    this.childPadding = 10.0,
   });
 
   final Widget child;
@@ -17,6 +18,7 @@ class BasePlate extends StatelessWidget {
   final int spreadRadius;
   final int blurRadius;
   final bool useBorder;
+  final double childPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +42,7 @@ class BasePlate extends StatelessWidget {
               ],
       ),
       child: Padding(
-        padding: const EdgeInsets.all(10.0),
+        padding: EdgeInsets.all(childPadding),
         child: child,
       ),
     );


### PR DESCRIPTION
- use a rounded square form to avoid clipping for hard edge square forms, i.e. to avoid this:
![grafik](https://user-images.githubusercontent.com/15329494/212696858-8ba21c2a-e516-48cf-b189-fcee05013491.png)

- adjust padding to make them look bigger when they are very small
- always make the fallback icon light to avoid bulls-eye effect, to be clear, to avoid this:
![grafik](https://user-images.githubusercontent.com/15329494/212696985-7eb88f4c-8a2e-43cc-8eb4-f5d57050eaf9.png)

- adjust fallback icon borders

After (dark):
![grafik](https://user-images.githubusercontent.com/15329494/212695020-95cf57ca-bc66-44f9-a1b2-f0433a8ce208.png)
![grafik](https://user-images.githubusercontent.com/15329494/212695049-300832ab-6fbb-4047-9ba8-21373f99bbb2.png)
![grafik](https://user-images.githubusercontent.com/15329494/212695101-4dabaa3e-ef6d-4ab9-9c7f-5f24843a2897.png)
![grafik](https://user-images.githubusercontent.com/15329494/212695138-6b1849b2-7d36-4ed8-b164-3e104cfc7617.png)

After (light):
![grafik](https://user-images.githubusercontent.com/15329494/212696770-2c867eeb-6c3b-4f65-a52c-58cda04f80b2.png)
![grafik](https://user-images.githubusercontent.com/15329494/212695603-d8789fd5-6d97-4998-8c84-81441d8f7087.png)
![grafik](https://user-images.githubusercontent.com/15329494/212695696-b85f5a81-67ad-4882-8e30-beb19057d776.png)
![grafik](https://user-images.githubusercontent.com/15329494/212695173-a2940256-da89-4ecd-b48b-922e9ec780a2.png)
