### PR TITLE
move the `Scaffold` with the `SearchField` to `ExplorePage`

### DIFF
--- a/lib/app/common/loading_banner_grid.dart
+++ b/lib/app/common/loading_banner_grid.dart
@@ -33,28 +33,75 @@ class LoadingBannerGrid extends StatelessWidget {
         light ? const Color.fromARGB(120, 228, 228, 228) : YaruColors.jet;
     final shimmerHighLight =
         light ? const Color.fromARGB(200, 247, 247, 247) : YaruColors.coolGrey;
-    return GridView.builder(
-      padding: kGridPadding,
-      gridDelegate: kGridDelegate,
-      shrinkWrap: true,
-      itemCount: 40,
-      itemBuilder: (context, index) {
-        return Shimmer.fromColors(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Shimmer.fromColors(
           baseColor: shimmerBase,
           highlightColor: shimmerHighLight,
-          child: YaruBanner.tile(
-            title: const Text(
-              '',
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: kPagePadding,
+              left: kPagePadding,
+              bottom: kPagePadding - 5,
             ),
-            icon: const Padding(
-              padding: kIconPadding,
-              child: AppIcon(
-                iconUrl: null,
-              ),
+            child: Wrap(
+              alignment: WrapAlignment.start,
+              runAlignment: WrapAlignment.start,
+              crossAxisAlignment: WrapCrossAlignment.start,
+              spacing: 10,
+              children: const [_DummyButton(), _DummyButton()],
             ),
           ),
-        );
-      },
+        ),
+        Expanded(
+          child: GridView.builder(
+            padding: const EdgeInsets.only(
+              bottom: 15,
+              right: 15,
+              left: 15,
+            ),
+            gridDelegate: kGridDelegate,
+            shrinkWrap: true,
+            itemCount: 40,
+            itemBuilder: (context, index) {
+              return Shimmer.fromColors(
+                baseColor: shimmerBase,
+                highlightColor: shimmerHighLight,
+                child: YaruBanner.tile(
+                  title: const Text(
+                    '',
+                  ),
+                  icon: const Padding(
+                    padding: kIconPadding,
+                    child: AppIcon(
+                      iconUrl: null,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DummyButton extends StatelessWidget {
+  const _DummyButton({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 40,
+      width: 150,
+      decoration: BoxDecoration(
+        color: Colors.black,
+        borderRadius: BorderRadius.circular(6),
+      ),
     );
   }
 }

--- a/lib/app/common/loading_banner_grid.dart
+++ b/lib/app/common/loading_banner_grid.dart
@@ -33,65 +33,70 @@ class LoadingBannerGrid extends StatelessWidget {
         light ? const Color.fromARGB(120, 228, 228, 228) : YaruColors.jet;
     final shimmerHighLight =
         light ? const Color.fromARGB(200, 247, 247, 247) : YaruColors.coolGrey;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Shimmer.fromColors(
+    return GridView.builder(
+      padding: const EdgeInsets.only(
+        bottom: 15,
+        right: 15,
+        left: 15,
+      ),
+      gridDelegate: kGridDelegate,
+      shrinkWrap: true,
+      itemCount: 40,
+      itemBuilder: (context, index) {
+        return Shimmer.fromColors(
           baseColor: shimmerBase,
           highlightColor: shimmerHighLight,
-          child: Padding(
-            padding: const EdgeInsets.only(
-              top: kPagePadding,
-              left: kPagePadding,
-              bottom: kPagePadding - 5,
+          child: YaruBanner.tile(
+            title: const Text(
+              '',
             ),
-            child: Wrap(
-              alignment: WrapAlignment.start,
-              runAlignment: WrapAlignment.start,
-              crossAxisAlignment: WrapCrossAlignment.start,
-              spacing: 10,
-              children: const [_DummyButton(), _DummyButton()],
+            icon: const Padding(
+              padding: kIconPadding,
+              child: AppIcon(
+                iconUrl: null,
+              ),
             ),
           ),
-        ),
-        Expanded(
-          child: GridView.builder(
-            padding: const EdgeInsets.only(
-              bottom: 15,
-              right: 15,
-              left: 15,
-            ),
-            gridDelegate: kGridDelegate,
-            shrinkWrap: true,
-            itemCount: 40,
-            itemBuilder: (context, index) {
-              return Shimmer.fromColors(
-                baseColor: shimmerBase,
-                highlightColor: shimmerHighLight,
-                child: YaruBanner.tile(
-                  title: const Text(
-                    '',
-                  ),
-                  icon: const Padding(
-                    padding: kIconPadding,
-                    child: AppIcon(
-                      iconUrl: null,
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      ],
+        );
+      },
     );
   }
 }
 
-class _DummyButton extends StatelessWidget {
-  const _DummyButton({
-    Key? key,
-  }) : super(key: key);
+class LoadingExploreHeader extends StatelessWidget {
+  const LoadingExploreHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    var light = theme.brightness == Brightness.light;
+    final shimmerBase =
+        light ? const Color.fromARGB(120, 228, 228, 228) : YaruColors.jet;
+    final shimmerHighLight =
+        light ? const Color.fromARGB(200, 247, 247, 247) : YaruColors.coolGrey;
+    return Shimmer.fromColors(
+      baseColor: shimmerBase,
+      highlightColor: shimmerHighLight,
+      child: Padding(
+        padding: const EdgeInsets.only(
+          top: kPagePadding,
+          left: kPagePadding,
+          bottom: kPagePadding - 5,
+        ),
+        child: Wrap(
+          alignment: WrapAlignment.start,
+          runAlignment: WrapAlignment.start,
+          crossAxisAlignment: WrapCrossAlignment.start,
+          spacing: 10,
+          children: const [_LoadingButton(), _LoadingButton()],
+        ),
+      ),
+    );
+  }
+}
+
+class _LoadingButton extends StatelessWidget {
+  const _LoadingButton();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/explore/explore_error_page.dart
+++ b/lib/app/explore/explore_error_page.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:software/app/common/search_field.dart';
-import 'package:software/app/explore/explore_header.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -10,11 +8,9 @@ class ExploreErrorPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final searchQuery = context.select((ExploreModel m) => m.searchQuery);
-    final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
     final errorMessage = context.select((ExploreModel m) => m.errorMessage);
 
-    final page = ListView(
+    return ListView(
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
         Center(
@@ -29,18 +25,6 @@ class ExploreErrorPage extends StatelessWidget {
           ),
         )
       ],
-    );
-
-    return Scaffold(
-      appBar: AppBar(
-        flexibleSpace: SearchField(
-          searchQuery: searchQuery,
-          onChanged: setSearchQuery,
-        ),
-      ),
-      body: Column(
-        children: [const ExploreHeader(), Expanded(child: page)],
-      ),
     );
   }
 }

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:software/app/common/search_field.dart';
 import 'package:software/app/explore/explore_error_page.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/app/explore/offline_page.dart';
@@ -28,6 +29,7 @@ import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class ExplorePage extends StatelessWidget {
   const ExplorePage({Key? key}) : super(key: key);
@@ -64,11 +66,19 @@ class ExplorePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final showErrorPage = context.select((ExploreModel m) => m.showErrorPage);
     final showSearchPage = context.select((ExploreModel m) => m.showSearchPage);
+    final searchQuery = context.select((ExploreModel m) => m.searchQuery);
+    final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
 
-    if (showErrorPage) {
-      return const ExploreErrorPage();
-    } else {
-      return showSearchPage ? const SearchPage() : const StartPage();
-    }
+    return Scaffold(
+      appBar: YaruWindowTitleBar(
+        title: SearchField(
+          searchQuery: searchQuery,
+          onChanged: setSearchQuery,
+        ),
+      ),
+      body: showErrorPage
+          ? const ExploreErrorPage()
+          : (showSearchPage ? const SearchPage() : const StartPage()),
+    );
   }
 }

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -22,11 +22,9 @@ import 'package:software/app/common/app_finding.dart';
 import 'package:software/app/common/app_format.dart';
 import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
-import 'package:software/app/common/search_field.dart';
 import 'package:software/app/explore/explore_header.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/l10n/l10n.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 class SearchPage extends StatelessWidget {
   const SearchPage({
@@ -36,8 +34,6 @@ class SearchPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final search = context.select((ExploreModel m) => m.search);
-    final searchQuery = context.select((ExploreModel m) => m.searchQuery);
-    final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
     final showSnap = context.select(
       (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.snap),
     );
@@ -45,8 +41,9 @@ class SearchPage extends StatelessWidget {
       (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.packageKit),
     );
     context.select((ExploreModel m) => m.selectedSection);
+    context.select((ExploreModel m) => m.search());
 
-    final grid = FutureBuilder<Map<String, AppFinding>>(
+    return FutureBuilder<Map<String, AppFinding>>(
       future: search(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
@@ -54,45 +51,34 @@ class SearchPage extends StatelessWidget {
         }
 
         return snapshot.hasData && snapshot.data!.isNotEmpty
-            ? GridView.builder(
-                padding: const EdgeInsets.only(
-                  bottom: kPagePadding - 5,
-                  left: kPagePadding - 5,
-                  right: kPagePadding - 5,
-                ),
-                gridDelegate: kGridDelegate,
-                shrinkWrap: true,
-                itemCount: snapshot.data!.length,
-                itemBuilder: (context, index) {
-                  final appFinding = snapshot.data!.entries.elementAt(index);
-                  return AppBanner(
-                    appFinding: appFinding,
-                    showSnap: showSnap,
-                    showPackageKit: showPackageKit,
-                  );
-                },
+            ? Column(
+                children: [
+                  const ExploreHeader(),
+                  Expanded(
+                    child: GridView.builder(
+                      padding: const EdgeInsets.only(
+                        bottom: 15,
+                        right: 15,
+                        left: 15,
+                      ),
+                      gridDelegate: kGridDelegate,
+                      shrinkWrap: true,
+                      itemCount: snapshot.data!.length,
+                      itemBuilder: (context, index) {
+                        final appFinding =
+                            snapshot.data!.entries.elementAt(index);
+                        return AppBanner(
+                          appFinding: appFinding,
+                          showSnap: showSnap,
+                          showPackageKit: showPackageKit,
+                        );
+                      },
+                    ),
+                  ),
+                ],
               )
             : _NoSearchResultPage(message: context.l10n.noPackageFound);
       },
-    );
-
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        titleSpacing: 0,
-        centerTitle: true,
-        title: SearchField(
-          searchQuery: searchQuery,
-          onChanged: setSearchQuery,
-        ),
-      ),
-      body: Column(
-        children: [
-          const ExploreHeader(),
-          Expanded(
-            child: grid,
-          )
-        ],
-      ),
     );
   }
 }

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -47,7 +47,13 @@ class SearchPage extends StatelessWidget {
       future: search(),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const LoadingBannerGrid();
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              LoadingExploreHeader(),
+              Expanded(child: LoadingBannerGrid()),
+            ],
+          );
         }
 
         return snapshot.hasData && snapshot.data!.isNotEmpty

--- a/lib/app/explore/start_page.dart
+++ b/lib/app/explore/start_page.dart
@@ -20,14 +20,12 @@ import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
-import 'package:software/app/common/search_field.dart';
 import 'package:software/app/common/snap/snap_section.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/app/explore/section_banner.dart';
 import 'package:software/app/explore/section_grid.dart';
 import 'package:software/snapx.dart';
 import 'package:yaru_colors/yaru_colors.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 class StartPage extends StatefulWidget {
   const StartPage({
@@ -60,13 +58,12 @@ class _StartPageState extends State<StartPage> {
 
   @override
   Widget build(BuildContext context) {
-    final searchQuery = context.select((ExploreModel m) => m.searchQuery);
-    final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
     final sectionSnapsAll = context.select((ExploreModel m) {
       return m.sectionNameToSnapsMap[SnapSection.all];
     });
 
-    final page = SingleChildScrollView(
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(top: 15),
       controller: _controller,
       child: Column(
         children: [
@@ -75,20 +72,6 @@ class _StartPageState extends State<StartPage> {
             snaps: sectionSnapsAll,
           ),
         ],
-      ),
-    );
-
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        titleSpacing: 0,
-        title: SearchField(
-          searchQuery: searchQuery,
-          onChanged: setSearchQuery,
-        ),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.only(top: 15),
-        child: page,
       ),
     );
   }


### PR DESCRIPTION
Bonus: adapted the loading grid to include a fake explore header

https://user-images.githubusercontent.com/15329494/213189875-40a2046a-435d-4d4c-b187-a56d215cb10a.mp4



Fixes #814