### PR TITLE
Search page optimization

### DIFF
--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -15,6 +15,8 @@
  *
  */
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:software/l10n/l10n.dart';
@@ -38,6 +40,7 @@ class SearchField extends StatefulWidget {
 
 class _SearchFieldState extends State<SearchField> {
   final TextEditingController _controller = TextEditingController();
+  Timer? onChangedTimer;
 
   @override
   void initState() {
@@ -54,6 +57,16 @@ class _SearchFieldState extends State<SearchField> {
   void onDoubleTap() {
     _controller.selection =
         TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
+  }
+
+  void onChanged(String value) {
+    onChangedTimer?.cancel();
+    setState(() {
+      onChangedTimer = Timer(
+        const Duration(milliseconds: 200),
+        () => widget.onChanged(value),
+      );
+    });
   }
 
   @override
@@ -74,7 +87,7 @@ class _SearchFieldState extends State<SearchField> {
             child: TextField(
               autofocus: widget.autofocus,
               controller: _controller,
-              onChanged: widget.onChanged,
+              onChanged: onChanged,
               textInputAction: TextInputAction.send,
               decoration: InputDecoration(
                 filled: true,

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -41,7 +41,7 @@ class SearchPage extends StatelessWidget {
       (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.packageKit),
     );
     context.select((ExploreModel m) => m.selectedSection);
-    context.select((ExploreModel m) => m.search());
+    context.select((ExploreModel m) => m.searchQuery);
 
     return FutureBuilder<Map<String, AppFinding>>(
       future: search(),


### PR DESCRIPTION
* fix `SearchPage` rebuilds
* add 200ms grace period to `SearchField` (i.e. start search only 200ms after the user stops typing)

Before

https://user-images.githubusercontent.com/113362648/213253723-234088db-2111-4d82-bdbe-8ee533249fd5.mp4

After

https://user-images.githubusercontent.com/113362648/213253787-16148abd-9558-47ce-a6a3-793da477ef5b.mp4


