### PR TITLE
Bring back dark AppIcon loading icon without a baseplate

### DIFF
--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -19,9 +19,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
-
-const _borderColor = Color.fromARGB(255, 189, 189, 189);
+import 'package:software/app/common/border_container.dart';
 
 class AppIcon extends StatelessWidget {
   const AppIcon({
@@ -39,19 +37,29 @@ class AppIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fallBackIcon = YaruBorderContainer(
-      border: Border.all(color: _borderColor),
-      borderRadius: BorderRadius.circular(200),
+    final fallBackIcon = BorderContainer(
+      borderColor: color,
+      containerPadding: EdgeInsets.zero,
+      borderRadius: 200,
       width: size,
       height: size,
       child: _FallBackIcon(
         size: size,
+        borderColor: borderColor,
+        color: color,
       ),
     );
 
-    final shimmerBase = color ?? (const Color.fromARGB(120, 228, 228, 228));
-    final shimmerHighLight =
-        borderColor ?? (const Color.fromARGB(200, 247, 247, 247));
+    final theme = Theme.of(context);
+    var light = theme.brightness == Brightness.light;
+    final shimmerBase = color ??
+        (light
+            ? const Color.fromARGB(120, 228, 228, 228)
+            : const Color.fromARGB(255, 51, 51, 51));
+    final shimmerHighLight = borderColor ??
+        (light
+            ? const Color.fromARGB(200, 247, 247, 247)
+            : const Color.fromARGB(255, 57, 57, 57));
     final fallBackLoadingIcon = Shimmer.fromColors(
       baseColor: shimmerBase,
       highlightColor: shimmerHighLight,
@@ -85,19 +93,37 @@ class _FallBackIcon extends StatelessWidget {
   const _FallBackIcon({
     Key? key,
     required this.size,
+    this.borderColor,
+    this.color,
   }) : super(key: key);
 
   final double size;
+  final Color? borderColor;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    const border = BorderSide(
-      color: _borderColor,
-      width: 0.5,
+    final theme = Theme.of(context);
+    final light = theme.brightness == Brightness.light;
+    final border = BorderSide(
+      color: borderColor ?? (light ? Colors.white : theme.dividerColor),
+      width: light ? 0.5 : 0.3,
     );
-    const shadeMax = Color.fromARGB(255, 199, 199, 199);
-    const shadeMid = Color.fromARGB(255, 214, 214, 214);
-    const shadeMin = Color.fromARGB(255, 236, 236, 236);
+    final shadeMax = color != null
+        ? color!.withOpacity(0.1)
+        : light
+            ? theme.dividerColor.withOpacity(0.1)
+            : theme.colorScheme.onSurface.withOpacity(0.03);
+    final shadeMid = color != null
+        ? color!.withOpacity(0.05)
+        : light
+            ? theme.dividerColor.withOpacity(0.05)
+            : theme.colorScheme.onSurface.withOpacity(0.015);
+    final shadeMin = color != null
+        ? color!.withOpacity(0.005)
+        : light
+            ? theme.dividerColor.withOpacity(0.005)
+            : theme.colorScheme.onSurface.withOpacity(0.005);
     return ClipOval(
       child: FittedBox(
         fit: BoxFit.none,
@@ -109,7 +135,7 @@ class _FallBackIcon extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.all(size),
-                    decoration: const BoxDecoration(
+                    decoration: BoxDecoration(
                       border: Border(
                         right: border,
                       ),
@@ -118,7 +144,7 @@ class _FallBackIcon extends StatelessWidget {
                   ),
                   Container(
                     padding: EdgeInsets.all(size),
-                    decoration: const BoxDecoration(
+                    decoration: BoxDecoration(
                       color: shadeMax,
                       border: Border(
                         top: border,
@@ -132,7 +158,7 @@ class _FallBackIcon extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.all(size * 1.2),
-                    decoration: const BoxDecoration(
+                    decoration: BoxDecoration(
                       color: shadeMin,
                       border: Border(
                         bottom: border,
@@ -141,7 +167,7 @@ class _FallBackIcon extends StatelessWidget {
                   ),
                   Container(
                     padding: EdgeInsets.all(size * 1.2),
-                    decoration: const BoxDecoration(color: shadeMid),
+                    decoration: BoxDecoration(color: shadeMid),
                   ),
                 ],
               ),


### PR DESCRIPTION
Info: they were removed because we tried the white baseplate, which we reverted but I have forgotten to revert the appicon fallback icon for the dark theme

https://user-images.githubusercontent.com/15329494/213312047-420df927-794c-46f0-91c2-1b3e7406e94b.mp4



Fixes #817