### PR TITLE
BorderContainer: use YaruBorderContainer

### DIFF
--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -39,7 +39,7 @@ class AppIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final fallBackIcon = BorderContainer(
       borderColor: color,
-      containerPadding: EdgeInsets.zero,
+      padding: EdgeInsets.zero,
       borderRadius: 200,
       width: size,
       height: size,

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -161,7 +161,7 @@ class _ReviewDetailsDialog extends StatelessWidget {
           : userReviews!
               .map(
                 (e) => BorderContainer(
-                  childPadding: const EdgeInsets.only(
+                  padding: const EdgeInsets.only(
                     left: kYaruPagePadding,
                     right: kYaruPagePadding,
                     bottom: kYaruPagePadding,

--- a/lib/app/common/border_container.dart
+++ b/lib/app/common/border_container.dart
@@ -17,17 +17,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:software/app/common/constants.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
-/// A [Container] with predefined [Decoration].
-/// The [Decoration] has a [Border] with [Divider]'s color.
-/// The [BorderContainer] wraps its [child] in a [Padding]
-/// which defaults to 20 on all sides
+/// A [YaruBorderContainer] with software specific defaults.
 class BorderContainer extends StatelessWidget {
   const BorderContainer({
     super.key,
     this.height,
     this.width,
-    this.childPadding,
     this.child,
     this.borderRadius = 10,
     this.alignment,
@@ -37,7 +34,7 @@ class BorderContainer extends StatelessWidget {
     this.transform,
     this.transformAlignment,
     this.clipBehavior = Clip.none,
-    this.containerPadding,
+    this.padding = const EdgeInsets.all(kYaruPagePadding),
     this.borderColor,
   });
 
@@ -47,12 +44,8 @@ class BorderContainer extends StatelessWidget {
   /// Forwarded to [Container]
   final double? width;
 
-  /// The [Padding] which the [child] is surrounded by. Defaults to 20
-  /// on all sides.
-  final EdgeInsets? childPadding;
-
   /// Forwarded to [Container]
-  final EdgeInsets? containerPadding;
+  final EdgeInsets? padding;
 
   /// Forwarded to [Container]
   final Widget? child;
@@ -89,31 +82,21 @@ class BorderContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final light = theme.brightness == Brightness.light;
-    final container = Container(
+    final container = YaruBorderContainer(
+      borderRadius: BorderRadius.circular(borderRadius),
       alignment: alignment,
       constraints: constraints,
       margin: margin,
       transform: transform,
       transformAlignment: transformAlignment,
       clipBehavior: clipBehavior,
-      padding: containerPadding ?? const EdgeInsets.all(20),
+      padding: padding ?? const EdgeInsets.all(20),
       height: height,
       width: width,
-      decoration: BoxDecoration(
-        color: color ?? (light ? Colors.white : kBorderContainerBgDark),
-        borderRadius: BorderRadius.circular(borderRadius),
-        border: Border.all(
-          color: borderColor ?? theme.dividerColor,
-        ),
-      ),
+      color: color ?? (light ? Colors.white : kBorderContainerBgDark),
       child: child,
     );
 
-    return childPadding != null
-        ? Padding(
-            padding: childPadding!,
-            child: container,
-          )
-        : container;
+    return container;
   }
 }

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -151,7 +151,7 @@ class _PackagePageState extends State<PackagePage> {
 
     final preControls = widget.snap == null
         ? const BorderContainer(
-            containerPadding: EdgeInsets.symmetric(horizontal: 5),
+            padding: EdgeInsets.symmetric(horizontal: 5),
             borderRadius: 6,
             child: SizedBox(height: 40, child: DebianLabel()),
           )

--- a/lib/app/common/snap/snap_page.dart
+++ b/lib/app/common/snap/snap_page.dart
@@ -155,7 +155,7 @@ class _SnapPageState extends State<SnapPage> {
           )
         else
           const BorderContainer(
-            containerPadding: EdgeInsets.symmetric(horizontal: 5),
+            padding: EdgeInsets.symmetric(horizontal: 5),
             borderRadius: 6,
             child: SizedBox(height: 39, child: SnapLabel()),
           ),

--- a/lib/app/updates/package_updates_page.dart
+++ b/lib/app/updates/package_updates_page.dart
@@ -312,7 +312,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
             height: 10,
           ),
           BorderContainer(
-            childPadding: EdgeInsets.only(
+            padding: EdgeInsets.only(
               top: 20,
               bottom: 50,
               left: widget.hPadding,


### PR DESCRIPTION
BorderContainer: use YaruBorderContainer

No visual differences but this makes it a little easier to track properties and maintain the code.
Replacing all occurences of BorderContainer with YaruBordercontainer would also work but it would generate more lines of diff since the defaults for 90% of the constructor calls for software are defaulted in bordercontainer