### PR TITLE
Show number of available updates and progress in launcher icon

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -19,6 +19,7 @@ import 'package:collection/collection.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:gtk_application/gtk_application.dart';
+import 'package:launcher_entry/launcher_entry.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/app_model.dart';
 import 'package:software/app/app_splash_screen.dart';
@@ -46,6 +47,7 @@ class App extends StatelessWidget {
           getService<SnapService>(),
           getService<AppstreamService>(),
           getService<PackageService>(),
+          getService<LauncherEntryService>(),
         ),
         child: const App(),
       );

--- a/lib/app/app_model.dart
+++ b/lib/app/app_model.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:launcher_entry/launcher_entry.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/services/appstream/appstream_service.dart';
@@ -32,6 +33,7 @@ class AppModel extends SafeChangeNotifier implements WindowListener {
     this._snapService,
     this._appstreamService,
     this._packageService,
+    this._launcherEntryService,
   );
 
   final SnapService _snapService;
@@ -48,6 +50,9 @@ class AppModel extends SafeChangeNotifier implements WindowListener {
   final PackageService _packageService;
   StreamSubscription<bool>? _updatesChangedSub;
   StreamSubscription<UpdatesState>? _updatesStateSub;
+  StreamSubscription<int?>? _updatesPercentageSub;
+
+  final LauncherEntryService _launcherEntryService;
 
   UpdatesState? _updatesState;
   UpdatesState? get updatesState => _updatesState;
@@ -89,6 +94,21 @@ class AppModel extends SafeChangeNotifier implements WindowListener {
         _packageService.sendUpdateNotification(
           updatesAvailable: _updatesAvailable!,
         );
+        _launcherEntryService.update(count: updateAmount, countVisible: true);
+      } else {
+        _launcherEntryService.update(count: 0, countVisible: false);
+      }
+    });
+
+    _updatesPercentageSub =
+        _packageService.updatesPercentage.listen((percentage) {
+      if (percentage == null) {
+        _launcherEntryService.update(progressVisible: false);
+      } else {
+        _launcherEntryService.update(
+          progress: percentage / 100.0,
+          progressVisible: true,
+        );
       }
     });
   }
@@ -104,6 +124,7 @@ class AppModel extends SafeChangeNotifier implements WindowListener {
     _connectivitySub?.cancel();
     _updatesChangedSub?.cancel();
     _updatesStateSub?.cancel();
+    _updatesPercentageSub?.cancel();
 
     super.dispose();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:flutter/material.dart';
 import 'package:gtk_application/gtk_application.dart';
+import 'package:launcher_entry/launcher_entry.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/app.dart';
@@ -59,6 +60,12 @@ Future<void> main(List<String> args) async {
   registerService<GtkApplicationNotifier>(
     () => GtkApplicationNotifier(args),
     dispose: (s) => s.dispose(),
+  );
+
+  registerService<LauncherEntryService>(
+    (() => LauncherEntryService(
+          appUri: 'application://snap-store_snap-store.desktop',
+        )),
   );
 
   runApp(App.create());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   gtk_application: ^0.0.3
   handy_window: ^0.2.0
   intl: ^0.17.0
+  launcher_entry: ^0.1.0
   liquid_progress_indicator: ^0.4.0
   package_info_plus: ^1.4.2
   packagekit: ^0.2.4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,6 +70,7 @@ apps:
       - opengl
       - packagekit-control
       - snapd-control
+      - unity7
 
 slots:
   packagekit-svc:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gtk_application/gtk_application.dart';
+import 'package:launcher_entry/launcher_entry.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:software/app/app.dart';
 import 'package:software/services/appstream/appstream_service.dart';
@@ -21,6 +22,8 @@ class MockSnapService extends Mock implements SnapService {}
 
 class MockGtkApplicationNotifier extends Mock
     implements GtkApplicationNotifier {}
+
+class MockLauncherEntryService extends Mock implements LauncherEntryService {}
 
 void main() {
   testWidgets('Software app', (tester) async {
@@ -47,6 +50,9 @@ void main() {
     final updatesStateController = StreamController<UpdatesState>.broadcast();
     when(() => packageServiceMock.updatesState)
         .thenAnswer((_) => updatesStateController.stream);
+    final updatesPercentageController = StreamController<int?>.broadcast();
+    when(() => packageServiceMock.updatesPercentage)
+        .thenAnswer((_) => updatesPercentageController.stream);
 
     final snapServiceMock = MockSnapService();
     registerMockService<SnapService>(snapServiceMock);
@@ -70,6 +76,10 @@ void main() {
     final gtkApplicationNotifierMock = MockGtkApplicationNotifier();
     registerMockService<GtkApplicationNotifier>(gtkApplicationNotifierMock);
     when(() => gtkApplicationNotifierMock.commandLine).thenAnswer((_) => []);
+
+    final launcherEntryServiceMock = MockLauncherEntryService();
+    registerMockService<LauncherEntryService>(launcherEntryServiceMock);
+    when(launcherEntryServiceMock.update).thenAnswer((_) async {});
 
     await tester.pumpWidget(App.create());
   });


### PR DESCRIPTION
https://user-images.githubusercontent.com/113362648/214027558-5e0e5424-fa7c-4a24-b73f-58affd57f551.mp4

It would be nice to show an overall percentage somehow, but for now all we have is the percentage that `PackageKitItemProgressEvent` provides.

fix #687 