### PR TITLE
Use new fallback icon

### DIFF
--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -15,11 +15,9 @@
  *
  */
 
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:software/app/common/border_container.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 
 class AppIcon extends StatelessWidget {
   const AppIcon({
@@ -37,18 +35,7 @@ class AppIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fallBackIcon = BorderContainer(
-      borderColor: color,
-      padding: EdgeInsets.zero,
-      borderRadius: 200,
-      width: size,
-      height: size,
-      child: _FallBackIcon(
-        size: size,
-        borderColor: borderColor,
-        color: color,
-      ),
-    );
+    final fallBackIcon = YaruPlaceholderIcon(size: Size.square(size));
 
     final theme = Theme.of(context);
     var light = theme.brightness == Brightness.light;
@@ -86,95 +73,5 @@ class AppIcon extends StatelessWidget {
               errorBuilder: (context, error, stackTrace) => fallBackIcon,
             ),
           );
-  }
-}
-
-class _FallBackIcon extends StatelessWidget {
-  const _FallBackIcon({
-    Key? key,
-    required this.size,
-    this.borderColor,
-    this.color,
-  }) : super(key: key);
-
-  final double size;
-  final Color? borderColor;
-  final Color? color;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final light = theme.brightness == Brightness.light;
-    final border = BorderSide(
-      color: borderColor ?? (light ? Colors.white : theme.dividerColor),
-      width: light ? 0.5 : 0.3,
-    );
-    final shadeMax = color != null
-        ? color!.withOpacity(0.1)
-        : light
-            ? theme.dividerColor.withOpacity(0.1)
-            : theme.colorScheme.onSurface.withOpacity(0.03);
-    final shadeMid = color != null
-        ? color!.withOpacity(0.05)
-        : light
-            ? theme.dividerColor.withOpacity(0.05)
-            : theme.colorScheme.onSurface.withOpacity(0.015);
-    final shadeMin = color != null
-        ? color!.withOpacity(0.005)
-        : light
-            ? theme.dividerColor.withOpacity(0.005)
-            : theme.colorScheme.onSurface.withOpacity(0.005);
-    return ClipOval(
-      child: FittedBox(
-        fit: BoxFit.none,
-        child: Transform.rotate(
-          angle: -pi / 4,
-          child: Row(
-            children: [
-              Column(
-                children: [
-                  Container(
-                    padding: EdgeInsets.all(size),
-                    decoration: BoxDecoration(
-                      border: Border(
-                        right: border,
-                      ),
-                      color: shadeMid,
-                    ),
-                  ),
-                  Container(
-                    padding: EdgeInsets.all(size),
-                    decoration: BoxDecoration(
-                      color: shadeMax,
-                      border: Border(
-                        top: border,
-                        right: border,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              Column(
-                children: [
-                  Container(
-                    padding: EdgeInsets.all(size * 1.2),
-                    decoration: BoxDecoration(
-                      color: shadeMin,
-                      border: Border(
-                        bottom: border,
-                      ),
-                    ),
-                  ),
-                  Container(
-                    padding: EdgeInsets.all(size * 1.2),
-                    decoration: BoxDecoration(color: shadeMid),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/app/common/app_page/app_header.dart
+++ b/lib/app/common/app_page/app_header.dart
@@ -53,7 +53,9 @@ class BannerAppHeader extends StatelessWidget {
               SizedBox(
                 height: iconSize,
                 width: iconSize,
-                child: icon,
+                child: FittedBox(
+                  child: icon,
+                ),
               ),
               const SizedBox(width: kYaruPagePadding),
               Expanded(
@@ -125,7 +127,9 @@ class PageAppHeader extends StatelessWidget {
             SizedBox(
               height: iconSize,
               width: iconSize,
-              child: icon,
+              child: FittedBox(
+                child: icon,
+              ),
             ),
             Padding(
               padding: const EdgeInsets.all(kYaruPagePadding),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   xterm: ^3.3.0
   yaru: ^0.4.7
   yaru_colors: ^0.1.1
-  yaru_icons: ^1.0.1
+  yaru_icons: ^1.0.2
   yaru_widgets: ^2.0.0-beta-5
 
 dev_dependencies:


### PR DESCRIPTION
![Capture d’écran du 2023-01-24 11-31-38](https://user-images.githubusercontent.com/36476595/214269313-2cb61db9-7557-4250-9434-54d58a523684.png)
![Capture d’écran du 2023-01-24 11-31-21](https://user-images.githubusercontent.com/36476595/214269317-8621c029-f742-466e-971c-8897aa2c7ac7.png)

![Capture d’écran du 2023-01-24 11-50-35](https://user-images.githubusercontent.com/36476595/214273643-79166219-7736-413a-95b9-1258172b92a2.png)
![Capture d’écran du 2023-01-24 11-50-27](https://user-images.githubusercontent.com/36476595/214273649-1b6c22f9-ff55-40f2-adee-c27bf1672273.png)

I used a `FittedBox`, so the icon scale to the parent `SizedBox`.

Fixes #798