### PR TITLE
Add image banner without using it

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -17,10 +17,13 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+import 'package:shimmer/shimmer.dart';
+import 'package:snapd/snapd.dart';
 import 'package:software/app/common/app_finding.dart';
 import 'package:software/app/common/app_icon.dart';
 import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/packagekit/package_page.dart';
+import 'package:software/app/common/safe_network_image.dart';
 import 'package:software/app/common/snap/snap_page.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/appstream/appstream_utils.dart'
@@ -98,6 +101,68 @@ class AppBanner extends StatelessWidget {
       subtitle: subtitle,
       icon: appIcon,
       onTap: onTap,
+    );
+  }
+}
+
+class AppImageBanner extends StatelessWidget {
+  const AppImageBanner({super.key, required this.snap});
+
+  final Snap snap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    var light = theme.brightness == Brightness.light;
+
+    final fallBackLoadingIcon = Shimmer.fromColors(
+      baseColor: light ? kShimmerBaseLight : kShimmerBaseDark,
+      highlightColor: light ? kShimmerHighLightLight : kShimmerHighLightDark,
+      child: Container(
+        color: light ? kShimmerBaseLight : kShimmerBaseDark,
+        height: 300,
+        width: 480,
+      ),
+    );
+
+    return YaruBanner(
+      padding: EdgeInsets.zero,
+      onTap: () => SnapPage.push(
+        context: context,
+        snap: snap,
+      ),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 160,
+            child: ClipRRect(
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(10),
+                topRight: Radius.circular(10),
+              ),
+              child: SafeNetworkImage(
+                fallBackIcon: fallBackLoadingIcon,
+                url: snap.bannerUrl,
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          const SizedBox(
+            height: 5,
+          ),
+          Expanded(
+            child: ListTile(
+              title: Text(
+                snap.name,
+              ),
+              subtitle: SearchBannerSubtitle(
+                appFinding:
+                    AppFinding(snap: snap, rating: 5, totalRatings: 1234),
+              ),
+            ),
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import 'package:software/app/common/constants.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 class AppIcon extends StatelessWidget {
@@ -39,17 +40,9 @@ class AppIcon extends StatelessWidget {
 
     final theme = Theme.of(context);
     var light = theme.brightness == Brightness.light;
-    final shimmerBase = color ??
-        (light
-            ? const Color.fromARGB(120, 228, 228, 228)
-            : const Color.fromARGB(255, 51, 51, 51));
-    final shimmerHighLight = borderColor ??
-        (light
-            ? const Color.fromARGB(200, 247, 247, 247)
-            : const Color.fromARGB(255, 57, 57, 57));
     final fallBackLoadingIcon = Shimmer.fromColors(
-      baseColor: shimmerBase,
-      highlightColor: shimmerHighLight,
+      baseColor: light ? kShimmerBaseLight : kShimmerBaseDark,
+      highlightColor: light ? kShimmerHighLightLight : kShimmerHighLightDark,
       child: fallBackIcon,
     );
 

--- a/lib/app/common/constants.dart
+++ b/lib/app/common/constants.dart
@@ -36,6 +36,12 @@ const kGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
   crossAxisSpacing: 10,
   maxCrossAxisExtent: 550,
 );
+const kImageGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
+  maxCrossAxisExtent: 480,
+  mainAxisExtent: 300,
+  mainAxisSpacing: 10,
+  crossAxisSpacing: 10,
+);
 const kSnapcraftColor = Color(0xFFE95420);
 const kDebianColor = Color(0xFFdb2264);
 const kGreenLight = Color.fromARGB(255, 51, 121, 63);
@@ -48,3 +54,8 @@ const kFakeReviewText =
 
 const kBorderContainerBgDark = Color.fromARGB(255, 46, 46, 46);
 const badgeTextStyle = TextStyle(color: Colors.white, fontSize: 10);
+
+const kShimmerBaseLight = Color.fromARGB(120, 228, 228, 228);
+const kShimmerBaseDark = Color.fromARGB(255, 51, 51, 51);
+const kShimmerHighLightLight = Color.fromARGB(200, 247, 247, 247);
+const kShimmerHighLightDark = Color.fromARGB(255, 57, 57, 57);

--- a/lib/app/common/safe_network_image.dart
+++ b/lib/app/common/safe_network_image.dart
@@ -7,28 +7,31 @@ class SafeNetworkImage extends StatelessWidget {
     required this.url,
     this.filterQuality = FilterQuality.medium,
     this.fit = BoxFit.fitHeight,
+    this.fallBackIcon,
   });
 
   final String? url;
   final FilterQuality filterQuality;
   final BoxFit fit;
+  final Widget? fallBackIcon;
 
   @override
   Widget build(BuildContext context) {
-    final fallbackIcon = Icon(
-      YaruIcons.image,
-      size: 60,
-      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
-    );
-    if (url == null) return fallbackIcon;
+    final fallBack = fallBackIcon ??
+        Icon(
+          YaruIcons.image,
+          size: 60,
+          color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+        );
+    if (url == null) return fallBack;
     return Image.network(
       url!,
       filterQuality: filterQuality,
       fit: fit,
       frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-        return frame == null ? fallbackIcon : child;
+        return frame == null ? fallBack : child;
       },
-      errorBuilder: (context, error, stackTrace) => fallbackIcon,
+      errorBuilder: (context, error, stackTrace) => fallBack,
     );
   }
 }

--- a/lib/app/common/snap/snap_section.dart
+++ b/lib/app/common/snap/snap_section.dart
@@ -187,8 +187,8 @@ enum SnapSection {
         ];
       case SnapSection.games:
         return [
-          const Color.fromARGB(255, 25, 119, 119).value,
-          YaruColors.viridian.value
+          const Color.fromARGB(255, 25, 119, 96).value,
+          const Color.fromARGB(255, 135, 3, 124).value
         ];
       case SnapSection.health_and_fitness:
         return [

--- a/lib/snapx.dart
+++ b/lib/snapx.dart
@@ -20,6 +20,8 @@ import 'package:snapd/snapd.dart';
 
 extension SnapX on Snap {
   String? get iconUrl => media.firstWhereOrNull((m) => m.type == 'icon')?.url;
+  String? get bannerUrl =>
+      media.firstWhereOrNull((m) => m.type == 'banner')?.url;
   List<String> get screenshotUrls =>
       media.where((m) => m.type == 'screenshot').map((m) => m.url).toList();
   bool get verified => publisher?.validation == 'verified';


### PR DESCRIPTION
Adds AppImageBanner without using it. **No visual changes**
Included are some additions to constants to not duplicate too much code.
If we want to re-use it we could do so by for example:

```dart

 final sectionSnapsGames = context.select((ExploreModel m) {
      return m.sectionNameToSnapsMap[SnapSection.games];
    });

....

GridView(
            shrinkWrap: true,
            padding: kGridPadding,
            physics: const NeverScrollableScrollPhysics(),
            gridDelegate: kImageGridDelegate,
            children: [
              for (final snap in sectionSnapsGames
                      ?.where((s) => s.bannerUrl != null)
                      .toList() ??
                  <Snap>[])
                AppImageBanner(snap: snap),
            ],
          )
```

![grafik](https://user-images.githubusercontent.com/15329494/214300743-554e0d19-52a9-411c-a89c-5ddace6a7c15.png)

![grafik](https://user-images.githubusercontent.com/15329494/214300419-36d35feb-652a-4acd-b2e9-0449f16fa87f.png)

