### PR TITLE
AppImageBanner: fixes

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -151,9 +151,18 @@ class AppImageBanner extends StatelessWidget {
             height: 5,
           ),
           Expanded(
-            child: ListTile(
+            child: YaruTile(
+              style: YaruTileStyle.banner,
+              padding: const EdgeInsets.only(
+                left: 15,
+                right: 15,
+                top: 6,
+                bottom: 5,
+              ),
               title: Text(
                 snap.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
               subtitle: SearchBannerSubtitle(
                 appFinding:

--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -25,14 +25,14 @@ class AppIcon extends StatelessWidget {
     super.key,
     required this.iconUrl,
     this.size = 45,
-    this.borderColor,
-    this.color,
+    this.loadingHighlight,
+    this.loadingBaseColor,
   });
 
   final String? iconUrl;
   final double size;
-  final Color? borderColor;
-  final Color? color;
+  final Color? loadingHighlight;
+  final Color? loadingBaseColor;
 
   @override
   Widget build(BuildContext context) {
@@ -41,8 +41,10 @@ class AppIcon extends StatelessWidget {
     final theme = Theme.of(context);
     var light = theme.brightness == Brightness.light;
     final fallBackLoadingIcon = Shimmer.fromColors(
-      baseColor: light ? kShimmerBaseLight : kShimmerBaseDark,
-      highlightColor: light ? kShimmerHighLightLight : kShimmerHighLightDark,
+      baseColor:
+          loadingBaseColor ?? (light ? kShimmerBaseLight : kShimmerBaseDark),
+      highlightColor: loadingHighlight ??
+          (light ? kShimmerHighLightLight : kShimmerHighLightDark),
       child: fallBackIcon,
     );
 

--- a/lib/app/explore/section_banner.dart
+++ b/lib/app/explore/section_banner.dart
@@ -122,8 +122,9 @@ class _PlatedIconState extends State<_PlatedIcon> {
             hovered: hovered,
             child: AppIcon(
               iconUrl: widget.snap.iconUrl,
-              color: dark ? const Color.fromARGB(255, 236, 236, 236) : null,
-              borderColor:
+              loadingBaseColor:
+                  dark ? const Color.fromARGB(255, 236, 236, 236) : null,
+              loadingHighlight:
                   dark ? const Color.fromARGB(255, 211, 211, 211) : null,
               size: 65,
             ),


### PR DESCRIPTION
- Avoid overflow and make sure the hand pointer cursor always shows up
![grafik](https://user-images.githubusercontent.com/15329494/214309654-bd274402-2a6e-467e-a19d-24dc02562aac.png)
 - [Re-add brightness agnostic highlights to appicon](https://github.com/ubuntu-flutter-community/software/pull/866/commits/0352c4ad3448d5c7c61905bba95b80c0c0a4264a)
(still not added to the app visibly!)