### PR TITLE
Replace xterm with LogView from ufp/ubuntu_widgets

### DIFF
--- a/lib/app/updates/package_updates_model.dart
+++ b/lib/app/updates/package_updates_model.dart
@@ -22,7 +22,6 @@ import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/packagekit/updates_state.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
-import 'package:xterm/xterm.dart';
 
 class PackageUpdatesModel extends SafeChangeNotifier {
   final PackageService _service;
@@ -39,7 +38,6 @@ class PackageUpdatesModel extends SafeChangeNotifier {
   StreamSubscription<bool>? _reposChangedSub;
   StreamSubscription<bool>? _updatesChangedSub;
   StreamSubscription<bool>? _selectionChanged;
-  StreamSubscription<String>? _terminalOutputSub;
 
   PackageUpdatesModel(
     this._service,
@@ -97,10 +95,6 @@ class PackageUpdatesModel extends SafeChangeNotifier {
     _selectionChanged = _service.selectionChanged.listen((event) {
       notifyListeners();
     });
-    _terminalOutputSub = _service.terminalOutput.listen((event) {
-      terminal.write(event);
-      terminal.nextLine();
-    });
 
     _service.getInstalledPackages();
     if (loadRepoList == true) {
@@ -122,10 +116,10 @@ class PackageUpdatesModel extends SafeChangeNotifier {
     _installedSub?.cancel();
     _reposChangedSub?.cancel();
     _selectionChanged?.cancel();
-    _terminalOutputSub?.cancel();
     super.dispose();
   }
 
+  Stream<String> get terminalOutput => _service.terminalOutput;
   List<PackageKitPackageId> get updates => _service.updates;
   PackageKitPackageId getUpdate(int index) => _service.getUpdate(index);
   PackageKitGroup getGroup(PackageKitPackageId id) =>
@@ -248,6 +242,4 @@ class PackageUpdatesModel extends SafeChangeNotifier {
   void logout() => _session.logout();
 
   void exitApp() => _service.exitApp();
-
-  final terminal = Terminal(maxLines: 50);
 }

--- a/lib/app/updates/package_updates_page.dart
+++ b/lib/app/updates/package_updates_page.dart
@@ -31,9 +31,8 @@ import 'package:software/app/updates/package_updates_model.dart';
 import 'package:software/services/packagekit/updates_state.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:xdg_icons/xdg_icons.dart';
-import 'package:xterm/ui.dart';
-import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -129,7 +128,7 @@ class _UpdatingPage extends StatefulWidget {
 }
 
 class _UpdatingPageState extends State<_UpdatingPage> {
-  final terminalController = TerminalController();
+  //final terminalController = TerminalController();
 
   @override
   Widget build(BuildContext context) {
@@ -174,14 +173,13 @@ class _UpdatingPageState extends State<_UpdatingPage> {
             child: SizedBox(
               height: 300,
               width: 600,
-              child: Padding(
-                padding: const EdgeInsets.only(
-                  top: kYaruPagePadding,
-                ),
-                child: TerminalView(
-                  model.terminal,
-                  controller: terminalController,
-                  theme: generateTerminalTheme(Theme.of(context)),
+              child: LogView(
+                log: model.terminalOutput,
+                style: TextStyle(
+                  inherit: false,
+                  fontFamily: 'Ubuntu Mono',
+                  fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+                  textBaseline: TextBaseline.alphabetic,
                 ),
               ),
             ),
@@ -397,33 +395,4 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
       ),
     );
   }
-}
-
-TerminalTheme generateTerminalTheme(ThemeData themeData) {
-  final light = themeData.brightness == Brightness.light;
-  return TerminalTheme(
-    cursor: light ? YaruColors.inkstone : YaruColors.porcelain,
-    selection: themeData.primaryColor,
-    foreground: themeData.colorScheme.onSurface,
-    background: themeData.colorScheme.surface,
-    black: YaruColors.jet,
-    white: YaruColors.porcelain,
-    red: YaruColors.error,
-    green: light ? kGreenLight : kGreenDark,
-    yellow: YaruColors.warning,
-    blue: YaruColors.blue,
-    magenta: YaruColors.magenta,
-    cyan: Colors.cyan,
-    brightBlack: YaruColors.inkstone,
-    brightRed: YaruColors.red,
-    brightGreen: kGreenLight,
-    brightYellow: Colors.yellow,
-    brightBlue: Colors.lightBlue,
-    brightMagenta: const Color.fromARGB(255, 208, 79, 236),
-    brightCyan: const Color.fromARGB(255, 44, 215, 238),
-    brightWhite: Colors.white,
-    searchHitBackground: themeData.colorScheme.background,
-    searchHitBackgroundCurrent: themeData.colorScheme.surface,
-    searchHitForeground: themeData.colorScheme.onSurface,
-  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,13 +42,16 @@ dependencies:
   snapd: ^0.4.6
   snowball_stemmer: ^0.1.0
   synchronized: ^3.0.0+3
+  ubuntu_widgets:
+    git:
+      url: https://github.com/canonical/ubuntu-flutter-plugins
+      path: packages/ubuntu_widgets
   ubuntu_service: ^0.2.0
   ubuntu_session: ^0.0.2
   url_launcher: ^6.1.2
   version: ^3.0.2
   window_manager: 0.3.0
   xdg_icons: ^0.0.1
-  xterm: ^3.3.0
   yaru: ^0.4.7
   yaru_colors: ^0.1.1
   yaru_icons: ^1.0.2


### PR DESCRIPTION
LogView is compatible with Flutter 3.7.0 but also lighter because it's just a plain read-only TextField under the hood.

| Before | After |
|---|---|
| ![Screenshot from 2023-01-26 11-37-10](https://user-images.githubusercontent.com/140617/214818467-382d6a55-3bea-49d2-a18a-4ef2cd46f687.png) | ![Screenshot from 2023-01-26 11-50-59](https://user-images.githubusercontent.com/140617/214818490-b1855861-eca8-40ae-b7d8-1428e9657958.png) |