### PR TITLE
Namespace badges.dart to avoid conflict with Badge in Flutter 3.7.0

### DIFF
--- a/lib/app/installed/installed_page.dart
+++ b/lib/app/installed/installed_page.dart
@@ -15,7 +15,7 @@
  *
  */
 
-import 'package:badges/badges.dart';
+import 'package:badges/badges.dart' as badges;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/common/app_format.dart';
@@ -102,7 +102,7 @@ class _InstalledPageIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Badge(
+    return badges.Badge(
       badgeColor: Theme.of(context).primaryColor,
       badgeContent: Text(
         count.toString(),

--- a/lib/app/updates/updates_page.dart
+++ b/lib/app/updates/updates_page.dart
@@ -1,4 +1,4 @@
-import 'package:badges/badges.dart';
+import 'package:badges/badges.dart' as badges;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/common/app_format.dart';
@@ -109,8 +109,8 @@ class _UpdatesIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     if (processing && count > 0) {
-      return Badge(
-        position: BadgePosition.topEnd(),
+      return badges.Badge(
+        position: badges.BadgePosition.topEnd(),
         badgeColor: count > 0 ? theme.primaryColor : Colors.transparent,
         badgeContent: count > 0
             ? Text(
@@ -123,7 +123,7 @@ class _UpdatesIcon extends StatelessWidget {
     } else if (processing && count == 0) {
       return const IndeterminateCircularProgressIcon();
     } else if (!processing && count > 0) {
-      return Badge(
+      return badges.Badge(
         badgeColor: theme.primaryColor,
         badgeContent: Text(
           count.toString(),


### PR DESCRIPTION
This is a temporary solution to allow step-by-step migration. We might eventually want to port to the new official [Badge](https://api.flutter.dev/flutter/material/Badge-class.html).