### PR TITLE
Flutter 3.7: code fixes

### DIFF
--- a/lib/app/app_splash_screen.dart
+++ b/lib/app/app_splash_screen.dart
@@ -71,7 +71,7 @@ class _StoreSplashScreenState extends State<StoreSplashScreen>
           Center(
             child: Text(
               context.l10n.justAMoment,
-              style: theme.textTheme.headline4,
+              style: theme.textTheme.headlineMedium,
               textAlign: TextAlign.center,
               overflow: TextOverflow.visible,
             ),

--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -34,7 +34,7 @@ class AppDescription extends StatelessWidget {
       expandIcon: const Icon(YaruIcons.pan_end),
       header: Text(
         context.l10n.description,
-        style: Theme.of(context).textTheme.headline6,
+        style: Theme.of(context).textTheme.titleLarge,
       ),
       child: Padding(
         padding: const EdgeInsets.only(top: 20),

--- a/lib/app/common/app_page/app_format_toggle_buttons.dart
+++ b/lib/app/common/app_page/app_format_toggle_buttons.dart
@@ -35,14 +35,16 @@ class SnapLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         const SizedBox(
           width: 10,
         ),
-        const Icon(
+        Icon(
           YaruIcons.snapcraft,
+          color: theme.colorScheme.onSurface,
           size: 16,
         ),
         const SizedBox(
@@ -64,14 +66,16 @@ class DebianLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         const SizedBox(
           width: 10,
         ),
-        const Icon(
+        Icon(
           YaruIcons.debian,
+          color: theme.colorScheme.onSurface,
           size: 16,
         ),
         const SizedBox(

--- a/lib/app/common/app_page/app_header.dart
+++ b/lib/app/common/app_page/app_header.dart
@@ -65,7 +65,7 @@ class BannerAppHeader extends StatelessWidget {
                   children: [
                     Text(
                       appData.title,
-                      style: theme.textTheme.headline3!.copyWith(
+                      style: theme.textTheme.displaySmall!.copyWith(
                         fontSize: 20,
                         color: theme.colorScheme.onSurface,
                       ),
@@ -140,7 +140,7 @@ class PageAppHeader extends StatelessWidget {
                 children: [
                   Text(
                     appData.title,
-                    style: theme.textTheme.headline3!.copyWith(
+                    style: theme.textTheme.displaySmall!.copyWith(
                       fontSize: scaledFontSize > 44 ? 44 : scaledFontSize,
                       color: theme.colorScheme.onSurface,
                     ),

--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -24,7 +24,7 @@ class AdditionalInformation extends StatelessWidget {
       isExpanded: true,
       header: Text(
         context.l10n.additionalInformation,
-        style: Theme.of(context).textTheme.headline6,
+        style: Theme.of(context).textTheme.titleLarge,
       ),
       child: ConstrainedBox(
         constraints: BoxConstraints.loose(const Size(1000, 200)),

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -113,7 +113,7 @@ class _AppPageState extends State<AppPage> {
         isExpanded: true,
         header: Text(
           context.l10n.gallery,
-          style: Theme.of(context).textTheme.headline6,
+          style: Theme.of(context).textTheme.titleLarge,
         ),
         child: YaruCarousel(
           controller: controller,

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -74,7 +74,7 @@ class _AppReviewsState extends State<AppReviews> {
         isExpanded: false,
         header: Text(
           context.l10n.reviewsAndRatings,
-          style: Theme.of(context).textTheme.headline6,
+          style: Theme.of(context).textTheme.titleLarge,
           overflow: TextOverflow.ellipsis,
         ),
         child: Column(

--- a/lib/app/common/dangerous_delayed_button.dart
+++ b/lib/app/common/dangerous_delayed_button.dart
@@ -66,7 +66,7 @@ class _DangerousDelayedButtonState extends State<DangerousDelayedButton> {
 
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
-        backgroundColor: Theme.of(context).errorColor,
+        backgroundColor: Theme.of(context).colorScheme.error,
       ),
       onPressed: disabled ? null : widget.onPressed,
       child: disabled

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -126,6 +126,7 @@ class _PackagePageState extends State<PackagePage> {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<PackageModel>();
+    final theme = Theme.of(context);
 
     final appData = AppData(
       publisherName: model.developerName ?? context.l10n.unknown,
@@ -194,7 +195,7 @@ class _PackagePageState extends State<PackagePage> {
       child: YaruExpandable(
         header: Text(
           '${context.l10n.dependencies} (${model.uninstalledDependencyNames.length})',
-          style: Theme.of(context).textTheme.headline6,
+          style: Theme.of(context).textTheme.titleLarge,
         ),
         child: Padding(
           padding: const EdgeInsets.only(top: 10),
@@ -203,7 +204,10 @@ class _PackagePageState extends State<PackagePage> {
                 .map(
                   (e) => ListTile(
                     title: Text(e),
-                    leading: const Icon(YaruIcons.package_deb),
+                    leading: Icon(
+                      YaruIcons.package_deb,
+                      color: theme.colorScheme.onSurface,
+                    ),
                   ),
                 )
                 .toList(),

--- a/lib/app/common/updates_splash_screen.dart
+++ b/lib/app/common/updates_splash_screen.dart
@@ -74,7 +74,7 @@ class _UpdatesSplashScreenState extends State<UpdatesSplashScreen>
         Center(
           child: Text(
             context.l10n.justAMoment,
-            style: Theme.of(context).textTheme.headline4,
+            style: Theme.of(context).textTheme.headlineMedium,
             textAlign: TextAlign.center,
             overflow: TextOverflow.visible,
           ),
@@ -85,7 +85,7 @@ class _UpdatesSplashScreenState extends State<UpdatesSplashScreen>
         Center(
           child: Text(
             context.l10n.checkingForUpdates,
-            style: Theme.of(context).textTheme.headline6!.copyWith(
+            style: Theme.of(context).textTheme.titleLarge!.copyWith(
                   fontWeight: FontWeight.w400,
                   color:
                       Theme.of(context).colorScheme.onSurface.withOpacity(0.7),

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -115,7 +115,7 @@ class _NoSearchResultPage extends StatelessWidget {
             width: 400,
             child: Text(
               message,
-              style: theme.textTheme.headline4?.copyWith(fontSize: 25),
+              style: theme.textTheme.headlineMedium?.copyWith(fontSize: 25),
               textAlign: TextAlign.center,
             ),
           ),

--- a/lib/app/explore/section_banner.dart
+++ b/lib/app/explore/section_banner.dart
@@ -53,7 +53,7 @@ class SectionBanner extends StatelessWidget {
                 constraints: BoxConstraints.loose(const Size(250, 1000)),
                 child: Text(
                   section.slogan(context.l10n),
-                  style: Theme.of(context).textTheme.headline5!.copyWith(
+                  style: Theme.of(context).textTheme.headlineSmall!.copyWith(
                     color: Colors.white,
                     shadows: [
                       Shadow(

--- a/lib/app/updates/package_updates_page.dart
+++ b/lib/app/updates/package_updates_page.dart
@@ -168,7 +168,7 @@ class _UpdatingPageState extends State<_UpdatingPage> {
           child: YaruExpandable(
             header: Text(
               'Details',
-              style: Theme.of(context).textTheme.headline6,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
             child: SizedBox(
               height: 300,
@@ -313,7 +313,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
           Center(
             child: Text(
               context.l10n.weHaveUpdates,
-              style: Theme.of(context).textTheme.headline5,
+              style: Theme.of(context).textTheme.headlineSmall,
               textAlign: TextAlign.center,
             ),
           ),
@@ -355,7 +355,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
                             Expanded(
                               child: Text(
                                 '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
-                                style: Theme.of(context).textTheme.headline6,
+                                style: Theme.of(context).textTheme.titleLarge,
                                 overflow: TextOverflow.ellipsis,
                               ),
                             )
@@ -363,7 +363,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
                         )
                       : Text(
                           '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
-                          style: Theme.of(context).textTheme.headline6,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                 ),
                 child: Padding(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,18 +7,21 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <gtk/gtk_plugin.h>
 #include <gtk_application/gtk_application_plugin.h>
 #include <handy_window/handy_window_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 #include <xdg_icons/xdg_icons_plugin.h>
-#include <yaru/yaru_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) gtk_application_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkApplicationPlugin");
   gtk_application_plugin_register_with_registrar(gtk_application_registrar);
@@ -37,7 +40,4 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) xdg_icons_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "XdgIconsPlugin");
   xdg_icons_plugin_register_with_registrar(xdg_icons_registrar);
-  g_autoptr(FlPluginRegistrar) yaru_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "YaruPlugin");
-  yaru_plugin_register_with_registrar(yaru_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,13 +4,13 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  gtk
   gtk_application
   handy_window
   screen_retriever
   url_launcher_linux
   window_manager
   xdg_icons
-  yaru
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,10 +52,13 @@ dependencies:
   version: ^3.0.2
   window_manager: 0.3.0
   xdg_icons: ^0.0.1
-  yaru: ^0.4.7
+  yaru: ^0.5.0
   yaru_colors: ^0.1.1
   yaru_icons: ^1.0.2
-  yaru_widgets: ^2.0.0-beta-5
+  yaru_widgets:
+    git:
+      url: https://github.com/ubuntu/yaru_widgets.dart
+      ref: ebb39b80e8892551de64a9e9c46e26f35d2d68ba
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
- use yaru 0.5.0 and yaru_widgets from git ref which also depends on yaru 0.5.0 to not create any visual regression with the new flutter stabel version
- ran dart fix to change text theme name changes
- updated some icons to use onSurface color to not create visual regression