### PR TITLE
Add clear icon to searchbar

### DIFF
--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -101,6 +101,19 @@ class _SearchFieldState extends State<SearchField> {
                 ),
                 prefixIconConstraints:
                     const BoxConstraints(minWidth: 40, minHeight: 0),
+                suffixIcon: widget.searchQuery.isNotEmpty
+                    ? IconButton(
+                        onPressed: _clear,
+                        icon: Center(
+                          child: Icon(
+                            YaruIcons.edit_clear,
+                            color: Theme.of(context).hintColor,
+                          ),
+                        ),
+                      )
+                    : null,
+                suffixIconConstraints:
+                    const BoxConstraints(maxWidth: 35, maxHeight: 35),
                 isDense: true,
                 contentPadding: const EdgeInsets.all(8),
                 fillColor:


### PR DESCRIPTION
Fixes regression, clear icon is back now if the field is not empty
![grafik](https://user-images.githubusercontent.com/15329494/215095006-c7b101cc-3a6d-4b92-a1b5-8a8a788a32b1.png)


Fixes #801