### PR TITLE
Move connectivity from AppModel into a small standalone unit

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -24,6 +24,7 @@ import 'package:provider/provider.dart';
 import 'package:software/app/app_model.dart';
 import 'package:software/app/app_splash_screen.dart';
 import 'package:software/app/common/close_confirmation_dialog.dart';
+import 'package:software/app/common/connectivity_notifier.dart';
 import 'package:software/app/common/page_item.dart';
 import 'package:software/app/explore/explore_page.dart';
 import 'package:software/app/installed/installed_page.dart';
@@ -41,14 +42,20 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 class App extends StatelessWidget {
   const App({super.key});
 
-  static Widget create() => ChangeNotifierProvider(
-        create: (context) => AppModel(
-          getService<Connectivity>(),
-          getService<SnapService>(),
-          getService<AppstreamService>(),
-          getService<PackageService>(),
-          getService<LauncherEntryService>(),
-        ),
+  static Widget create() => MultiProvider(
+        providers: [
+          ChangeNotifierProvider(
+            create: (context) => AppModel(
+              getService<SnapService>(),
+              getService<AppstreamService>(),
+              getService<PackageService>(),
+              getService<LauncherEntryService>(),
+            ),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => ConnectivityNotifier(getService<Connectivity>()),
+          ),
+        ],
         child: const App(),
       );
 
@@ -158,8 +165,7 @@ class __AppState extends State<_App> {
     final pageItems = [
       PageItem(
         titleBuilder: ExplorePage.createTitle,
-        builder: (context) =>
-            ExplorePage.create(context, model.appIsOnline, model.errorMessage),
+        builder: (context) => ExplorePage.create(context, model.errorMessage),
         iconBuilder: ExplorePage.createIcon,
       ),
       PageItem(

--- a/lib/app/common/connectivity_notifier.dart
+++ b/lib/app/common/connectivity_notifier.dart
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
+
+class ConnectivityNotifier extends SafeChangeNotifier {
+  ConnectivityNotifier(this._connectivity);
+
+  final Connectivity _connectivity;
+  StreamSubscription? _subscription;
+  ConnectivityResult? _result;
+
+  bool get isOnline => _result != ConnectivityResult.none;
+
+  Future<void> init() async {
+    _subscription ??=
+        _connectivity.onConnectivityChanged.listen(_updateConnectivity);
+    return _connectivity.checkConnectivity().then(_updateConnectivity);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    super.dispose();
+  }
+
+  void _updateConnectivity(ConnectivityResult result) {
+    if (_result == result) return;
+    _result = result;
+    notifyListeners();
+  }
+}

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/app_model.dart';
+import 'package:software/app/common/connectivity_notifier.dart';
 import 'package:software/app/common/search_field.dart';
 import 'package:software/app/explore/explore_error_page.dart';
 import 'package:software/app/explore/explore_model.dart';
@@ -35,13 +36,10 @@ import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class ExplorePage extends StatefulWidget {
-  const ExplorePage({Key? key, required this.online}) : super(key: key);
-
-  final bool online;
+  const ExplorePage({Key? key}) : super(key: key);
 
   static Widget create(
-    BuildContext context,
-    bool online, [
+    BuildContext context, [
     String? errorMessage,
   ]) {
     return ChangeNotifierProvider(
@@ -51,9 +49,7 @@ class ExplorePage extends StatefulWidget {
         getService<PackageService>(),
         errorMessage,
       )..init(),
-      child: ExplorePage(
-        online: online,
-      ),
+      child: const ExplorePage(),
     );
   }
 
@@ -82,6 +78,8 @@ class _ExplorePageState extends State<ExplorePage> {
         .read<AppModel>()
         .sidebarEvents
         .listen((_) => model.setSearchQuery(''));
+    final connectivity = context.read<ConnectivityNotifier>();
+    connectivity.init();
   }
 
   @override
@@ -92,6 +90,7 @@ class _ExplorePageState extends State<ExplorePage> {
 
   @override
   Widget build(BuildContext context) {
+    final connectivity = context.watch<ConnectivityNotifier>();
     final showErrorPage = context.select((ExploreModel m) => m.showErrorPage);
     final showSearchPage = context.select((ExploreModel m) => m.showSearchPage);
     final searchQuery = context.select((ExploreModel m) => m.searchQuery);
@@ -105,7 +104,7 @@ class _ExplorePageState extends State<ExplorePage> {
           onChanged: setSearchQuery,
         ),
       ),
-      body: !widget.online
+      body: !connectivity.isOnline
           ? const OfflinePage()
           : showErrorPage
               ? const ExploreErrorPage()

--- a/test/connectivity_test.dart
+++ b/test/connectivity_test.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:software/app/common/connectivity_notifier.dart';
+
+class MockConnectivity extends Mock implements Connectivity {}
+
+void main() {
+  test('connectivity', () async {
+    final controller = StreamController<ConnectivityResult>(sync: true);
+
+    final mock = MockConnectivity();
+    when(() => mock.checkConnectivity())
+        .thenAnswer((_) async => ConnectivityResult.none);
+    when(() => mock.onConnectivityChanged).thenAnswer((_) => controller.stream);
+
+    final notifier = ConnectivityNotifier(mock);
+    expect(notifier.isOnline, isTrue); // considered online by default
+
+    var wasNotified = 0;
+    var expectedNotified = 0;
+    notifier.addListener(() => wasNotified++);
+
+    await notifier.init();
+    expect(notifier.isOnline, isFalse);
+    expect(wasNotified, ++expectedNotified);
+
+    controller.add(ConnectivityResult.wifi);
+    expect(notifier.isOnline, isTrue);
+    expect(wasNotified, ++expectedNotified);
+
+    controller.add(ConnectivityResult.ethernet);
+    expect(notifier.isOnline, isTrue);
+    expect(wasNotified, ++expectedNotified);
+
+    controller.add(ConnectivityResult.none);
+    expect(notifier.isOnline, isFalse);
+    expect(wasNotified, ++expectedNotified);
+  });
+}


### PR DESCRIPTION
The connectivity status is not needed in AppModel. Having it in a small separate unit that only notifies connectivity status changes makes it cheap to watch anywhere connectivity status is needed. At the moment, the only place that needs the connectivity status is ExplorePage.

[connectivity.webm](https://user-images.githubusercontent.com/140617/215121727-58147503-43b9-4cc2-8d12-e9e77ecb1864.webm)