### PR TITLE
AppBanner & PackagePage: fill all infos with data or fallback string

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -201,9 +201,10 @@ class SearchBannerSubtitle extends StatelessWidget {
     }
 
     if (appFinding.appstream != null && showPackageKit && !showSnap) {
-      publisherName = appFinding.appstream!.developerName['C'] ??
-          appFinding.appstream!.developerName['en'] ??
-          appFinding.appstream!.developerName['en_GB'] ??
+      publisherName = appFinding.appstream!.developerName[WidgetsBinding
+              .instance.window.locale.countryCode
+              ?.toLowerCase()] ??
+          appFinding.appstream!.developerName['C'] ??
           appFinding.appstream!.localizedName();
     }
 

--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -201,16 +201,10 @@ class SearchBannerSubtitle extends StatelessWidget {
     }
 
     if (appFinding.appstream != null && showPackageKit && !showSnap) {
-      if (appFinding.appstream!
-              .developerName[Localizations.localeOf(context).toLanguageTag()] !=
-          null) {
-        publisherName = appFinding.appstream!
-            .developerName[Localizations.localeOf(context).toLanguageTag()]!;
-      } else if (appFinding.appstream!.urls.isNotEmpty) {
-        publisherName = appFinding.appstream!.urls
-            .firstWhere((element) => element.url.isNotEmpty)
-            .url;
-      }
+      publisherName = appFinding.appstream!.developerName['C'] ??
+          appFinding.appstream!.developerName['en'] ??
+          appFinding.appstream!.developerName['en_GB'] ??
+          appFinding.appstream!.localizedName();
     }
 
     return Column(

--- a/lib/app/common/app_data.dart
+++ b/lib/app/common/app_data.dart
@@ -25,18 +25,18 @@ class AppData {
   final String confinementName;
   final String version;
   final String license;
-  final String? installDate;
-  final String? installDateIsoNorm;
+  final String installDate;
+  final String installDateIsoNorm;
   final bool verified;
   final bool starredDeveloper;
-  final String? publisherName;
+  final String publisherName;
   final String website;
-  final String? contact;
+  final String contact;
   final List<String> screenShotUrls;
   final String description;
-  final bool? versionChanged;
-  final double? averageRating;
-  final List<AppReview>? userReviews;
+  final bool versionChanged;
+  final double averageRating;
+  final List<AppReview> userReviews;
   final AppFormat appFormat;
   final String appSize;
   final String releasedAt;
@@ -49,21 +49,21 @@ class AppData {
     required this.confinementName,
     required this.version,
     required this.license,
-    this.installDate,
-    this.installDateIsoNorm,
+    required this.installDate,
+    required this.installDateIsoNorm,
     required this.verified,
     required this.starredDeveloper,
-    this.publisherName,
+    required this.publisherName,
     required this.website,
     required this.screenShotUrls,
     required this.description,
-    this.versionChanged,
-    this.averageRating,
-    this.userReviews,
+    required this.versionChanged,
+    required this.averageRating,
+    required this.userReviews,
     required this.appFormat,
     required this.appSize,
     required this.releasedAt,
-    this.contact,
+    required this.contact,
   });
 }
 

--- a/lib/app/common/app_page/app_header.dart
+++ b/lib/app/common/app_page/app_header.dart
@@ -72,7 +72,7 @@ class BannerAppHeader extends StatelessWidget {
                     ),
                     PublisherName(
                       height: 18,
-                      publisherName: appData.publisherName ?? '',
+                      publisherName: appData.publisherName,
                       website: appData.website,
                       verified: appData.verified,
                       starDev: appData.starredDeveloper,
@@ -150,7 +150,7 @@ class PageAppHeader extends StatelessWidget {
                   Center(
                     child: PublisherName(
                       height: 20,
-                      publisherName: appData.publisherName ?? '',
+                      publisherName: appData.publisherName,
                       website: appData.website,
                       verified: appData.verified,
                       starDev: appData.starredDeveloper,

--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -39,7 +39,7 @@ class AdditionalInformation extends StatelessWidget {
             ),
             children: [
               PublisherInfoFragment(
-                publisherName: appData.publisherName ?? context.l10n.unknown,
+                publisherName: appData.publisherName,
                 website: appData.website,
                 verified: appData.verified,
                 starDev: appData.starredDeveloper,
@@ -61,9 +61,8 @@ class AdditionalInformation extends StatelessWidget {
               //   child: Text(context.l10n.unknown),
               // ),
               InstallDateInfoFragment(
-                installDateIsoNorm:
-                    appData.installDateIsoNorm ?? context.l10n.notInstalled,
-                installDate: appData.installDate ?? context.l10n.notInstalled,
+                installDateIsoNorm: appData.installDateIsoNorm,
+                installDate: appData.installDate,
               ),
               LinksInfoFragment(appData: appData),
             ],

--- a/lib/app/common/app_page/app_infos/app_infos.dart
+++ b/lib/app/common/app_page/app_infos/app_infos.dart
@@ -48,7 +48,7 @@ class AppInfos extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appInfos = [
-      RatingInfoFragment(averageRating: appData.averageRating ?? 0),
+      RatingInfoFragment(averageRating: appData.averageRating),
       ConfinementInfoFragment(
         strict: appData.strict,
         confinementName: appData.confinementName,

--- a/lib/app/common/app_page/app_infos/links_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/links_info_fragment.dart
@@ -14,17 +14,18 @@ class LinksInfoFragment extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 20),
-      child: AppInfoFragment(
-        mainAxisSize: MainAxisSize.max,
+    return AppInfoFragment(
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.center,
+      header: context.l10n.links,
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.center,
-        header: context.l10n.links,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
+        children: [
+          if (appData.website == context.l10n.unknown)
+            Text(appData.website)
+          else
             Tooltip(
               message: appData.website,
               child: Link(
@@ -32,17 +33,7 @@ class LinksInfoFragment extends StatelessWidget {
                 linkText: context.l10n.website,
               ),
             ),
-            if (appData.contact != null)
-              Tooltip(
-                message: '${context.l10n.contact}: ${appData.publisherName!}',
-                child: Link(
-                  url: appData.contact!,
-                  linkText:
-                      '${context.l10n.contact}: ${appData.publisherName!}',
-                ),
-              )
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/app/common/link.dart
+++ b/lib/app/common/link.dart
@@ -16,6 +16,7 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:software/l10n/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class Link extends StatelessWidget {
@@ -34,7 +35,9 @@ class Link extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       borderRadius: BorderRadius.circular(5),
-      onTap: () async => await launchUrl(Uri.parse(url)),
+      onTap: url == context.l10n.unknown
+          ? null
+          : () async => await launchUrl(Uri.parse(url)),
       child: Text(
         linkText,
         style: textStyle ??

--- a/lib/app/common/packagekit/package_model.dart
+++ b/lib/app/common/packagekit/package_model.dart
@@ -65,10 +65,10 @@ class PackageModel extends AppModel {
   String? get title => appstream?.localizedName() ?? packageId?.name;
 
   String? get developerName {
-    return appstream!.developerName['C'] ??
-        appstream!.developerName['en'] ??
-        appstream!.developerName['en_GB'] ??
-        appstream!.localizedName();
+    return appstream?.developerName['C'] ??
+        appstream?.developerName['en'] ??
+        appstream?.developerName['en_GB'] ??
+        appstream?.localizedName();
   }
 
   String? get releasedAt {
@@ -178,7 +178,8 @@ class PackageModel extends AppModel {
 
   /// The size of the package in bytes.
   int? _size;
-  String? getSize() => _size == null ? null : formatBytes(_size!, 2);
+  String? getFormattedSize() => _size == null ? null : formatBytes(_size!, 2);
+  int get size => _size ?? 0;
   set size(int? value) {
     if (value == null || value == _size) return;
     _size = value;

--- a/lib/app/common/packagekit/package_model.dart
+++ b/lib/app/common/packagekit/package_model.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 import 'package:appstream/appstream.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:software/app/common/app_model.dart';
@@ -65,10 +66,11 @@ class PackageModel extends AppModel {
   String? get title => appstream?.localizedName() ?? packageId?.name;
 
   String? get developerName {
-    return appstream?.developerName['C'] ??
-        appstream?.developerName['en'] ??
-        appstream?.developerName['en_GB'] ??
-        appstream?.localizedName();
+    final devName = appstream?.developerName[
+            WidgetsBinding.instance.window.locale.countryCode?.toLowerCase()] ??
+        appstream?.developerName['C'];
+
+    return devName ?? appstream?.localizedName();
   }
 
   String? get releasedAt {

--- a/lib/app/common/packagekit/package_model.dart
+++ b/lib/app/common/packagekit/package_model.dart
@@ -21,10 +21,10 @@ import 'dart:io';
 import 'package:appstream/appstream.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:software/app/common/app_model.dart';
+import 'package:software/app/common/utils.dart';
 import 'package:software/services/appstream/appstream_utils.dart';
 import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/packagekit/package_state.dart';
@@ -62,11 +62,13 @@ class PackageModel extends AppModel {
     }
   }
 
-  String get title => appstream?.localizedName() ?? packageId?.name ?? '';
+  String? get title => appstream?.localizedName() ?? packageId?.name;
 
   String? get developerName {
-    return appstream?.developerName[
-        WidgetsBinding.instance.window.locale.countryCode?.toLowerCase()];
+    return appstream!.developerName['C'] ??
+        appstream!.developerName['en'] ??
+        appstream!.developerName['en_GB'] ??
+        appstream!.localizedName();
   }
 
   String? get releasedAt {
@@ -148,39 +150,37 @@ class PackageModel extends AppModel {
   }
 
   /// The one line package summary, e.g. "Clipart for OpenOffice"
-  String _summary = '';
-  String get summary => _summary;
-  set summary(String value) {
-    if (value == _summary) return;
+  String? _summary;
+  String? get summary => _summary;
+  set summary(String? value) {
+    if (value == null || value == _summary) return;
     _summary = value;
     notifyListeners();
   }
 
   // The upstream project homepage.
-  String _url = '';
-  String get url => _url;
-  set url(String value) {
-    if (value == _url) return;
+  String? _url;
+  String? get url => _url;
+  set url(String? value) {
+    if (value == null || value == _url) return;
     _url = value;
     notifyListeners();
   }
 
   /// The license string, e.g. GPLv2+
-  String _license = '';
-  String get license => _license;
-  set license(String value) {
-    if (value.isEmpty ||
-        value == _license ||
-        (_license.isNotEmpty && value == 'unknown')) return;
+  String? _license;
+  String? get license => appstream?.projectLicense ?? _license;
+  set license(String? value) {
+    if (value == null || value == _license) return;
     _license = value;
     notifyListeners();
   }
 
   /// The size of the package in bytes.
-  int _size = 0;
-  int get size => _size;
-  set size(int value) {
-    if (value == _size) return;
+  int? _size;
+  String? getSize() => _size == null ? null : formatBytes(_size!, 2);
+  set size(int? value) {
+    if (value == null || value == _size) return;
     _size = value;
     notifyListeners();
   }

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -130,7 +130,7 @@ class _PackagePageState extends State<PackagePage> {
     final appData = AppData(
       publisherName: model.developerName ?? context.l10n.unknown,
       releasedAt: model.releasedAt ?? context.l10n.unknown,
-      appSize: model.getSize() ?? context.l10n.unknown,
+      appSize: model.getFormattedSize() ?? context.l10n.unknown,
       confinementName: context.l10n.classic,
       license: model.license ?? context.l10n.unknown,
       strict: false,

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -29,7 +29,6 @@ import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/packagekit/package_controls.dart';
 import 'package:software/app/common/packagekit/package_model.dart';
 import 'package:software/app/common/snap/snap_page.dart';
-import 'package:software/app/common/utils.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/appstream/appstream_utils.dart';
 import 'package:software/services/packagekit/package_service.dart';
@@ -131,23 +130,26 @@ class _PackagePageState extends State<PackagePage> {
     final appData = AppData(
       publisherName: model.developerName ?? context.l10n.unknown,
       releasedAt: model.releasedAt ?? context.l10n.unknown,
-      appSize: formatBytes(model.size, 2),
+      appSize: model.getSize() ?? context.l10n.unknown,
       confinementName: context.l10n.classic,
-      license: model.license,
+      license: model.license ?? context.l10n.unknown,
       strict: false,
       verified: false,
       starredDeveloper: false,
-      website: model.url,
-      summary: model.summary,
-      title: model.title,
+      website: model.url ?? context.l10n.unknown,
+      summary: model.summary ?? context.l10n.unknown,
+      title: model.title ?? context.l10n.unknown,
       name: model.packageId?.name ?? '',
       version: model.packageId?.version ?? '',
       screenShotUrls: model.screenshotUrls,
       description: model.description,
-      userReviews: model.userReviews,
-      averageRating: model.averageRating,
+      userReviews: model.userReviews ?? [],
+      averageRating: model.averageRating ?? 0.0,
       appFormat: AppFormat.packageKit,
-      versionChanged: model.versionChanged,
+      versionChanged: model.versionChanged ?? false,
+      contact: context.l10n.unknown,
+      installDate: context.l10n.unknown,
+      installDateIsoNorm: context.l10n.unknown,
     );
 
     final preControls = widget.snap == null
@@ -183,7 +185,7 @@ class _PackagePageState extends State<PackagePage> {
       showDeps: () => showDialog(
         context: context,
         builder: (context) => _ShowDepsDialog(
-          packageName: model.title,
+          packageName: model.title ?? context.l10n.unknown,
           onInstall: model.install,
           dependencies: model.uninstalledDependencyNames,
         ),

--- a/lib/app/common/snap/snap_page.dart
+++ b/lib/app/common/snap/snap_page.dart
@@ -122,10 +122,10 @@ class _SnapPageState extends State<SnapPage> {
       versionChanged:
           model.selectableChannels[model.channelToBeInstalled]?.version !=
               model.version,
-      userReviews: model.userReviews,
-      averageRating: model.averageRating,
+      userReviews: model.userReviews ?? [],
+      averageRating: model.averageRating ?? 0.0,
       appFormat: AppFormat.snap,
-      contact: model.contact,
+      contact: model.contact ?? context.l10n.unknown,
     );
 
     final controls = SnapControls(

--- a/lib/app/updates/update_dialog.dart
+++ b/lib/app/updates/update_dialog.dart
@@ -122,7 +122,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
                 context.l10n.size,
                 style: detailStyle,
               ),
-              trailing: Text(model.getSize() ?? context.l10n.unknown),
+              trailing: Text(model.getFormattedSize() ?? context.l10n.unknown),
             ),
             YaruTile(
               padding: detailPadding,

--- a/lib/app/updates/update_dialog.dart
+++ b/lib/app/updates/update_dialog.dart
@@ -20,7 +20,6 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:packagekit/packagekit.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/common/packagekit/package_model.dart';
-import 'package:software/app/common/utils.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/packagekit/package_state.dart';
@@ -123,7 +122,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
                 context.l10n.size,
                 style: detailStyle,
               ),
-              trailing: Text(formatBytes(model.size, 2)),
+              trailing: Text(model.getSize() ?? context.l10n.unknown),
             ),
             YaruTile(
               padding: detailPadding,
@@ -147,7 +146,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
                 context.l10n.license,
                 style: detailStyle,
               ),
-              trailing: Text(model.license),
+              trailing: Text(model.license ?? context.l10n.unknown),
             ),
             YaruTile(
               padding: detailPadding,
@@ -158,7 +157,8 @@ class _UpdateDialogState extends State<UpdateDialog> {
               trailing: IconButton(
                 splashRadius: 20,
                 tooltip: model.url,
-                onPressed: () => launchUrl(Uri.parse(model.url)),
+                onPressed: () =>
+                    launchUrl(Uri.parse(model.url ?? context.l10n.unknown)),
                 icon: Icon(
                   YaruIcons.external_link,
                   color: Theme.of(context).colorScheme.onSurface,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,10 +55,7 @@ dependencies:
   yaru: ^0.5.0
   yaru_colors: ^0.1.1
   yaru_icons: ^1.0.2
-  yaru_widgets:
-    git:
-      url: https://github.com/ubuntu/yaru_widgets.dart
-      ref: ebb39b80e8892551de64a9e9c46e26f35d2d68ba
+  yaru_widgets: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/test/services/package_service_test.dart
+++ b/test/services/package_service_test.dart
@@ -258,9 +258,9 @@ void main() {
       packageId: packageId,
       path: path,
     );
-    expect(model.summary, '');
-    expect(model.url, '');
-    expect(model.license, '');
+    expect(model.summary, isNull);
+    expect(model.url, isNull);
+    expect(model.license, isNull);
     expect(model.description, '');
     expect(model.isInstalled, isNull);
     return model;
@@ -337,7 +337,7 @@ void main() {
     expect(model.summary, 'a summary');
     expect(model.url, 'https://example.org/');
     expect(model.license, 'a license');
-    expect(model.getSize(), 43008);
+    expect(model.size, 43008);
     expect(model.description, 'a description');
   });
 

--- a/test/services/package_service_test.dart
+++ b/test/services/package_service_test.dart
@@ -261,7 +261,6 @@ void main() {
     expect(model.summary, '');
     expect(model.url, '');
     expect(model.license, '');
-    expect(model.size, 0);
     expect(model.description, '');
     expect(model.isInstalled, isNull);
     return model;
@@ -338,7 +337,7 @@ void main() {
     expect(model.summary, 'a summary');
     expect(model.url, 'https://example.org/');
     expect(model.license, 'a license');
-    expect(model.size, 43008);
+    expect(model.getSize(), 43008);
     expect(model.description, 'a description');
   });
 
@@ -423,7 +422,6 @@ void main() {
     expect(model.summary, 'a fox');
     expect(model.url, 'https://example.org/');
     expect(model.license, 'a license');
-    expect(model.size, 43008);
     expect(model.group, PackageKitGroup.internet);
     expect(model.description, 'a fire fox');
   });


### PR DESCRIPTION
- appstream uses kind of random locale strings
- in package page we also have the package id that can be used for the license :+1: 
- appstream sometimes has released at info, fallback to unkown as discussed with the other designers :+1: 
- reliable language tags are "C" (haha so funny 90s geeks), "en_GB" and "en"
- fallback in appbanner is the name, since most of the publisher names would be "UNKNOWN" otherwise which looks really weird here
- released at needs improvements in terms of formatting, in a second PR after this
- changed most of the model getters to return nullable types, to correctly digest this in the UI, we should do this in a different PR for more getters, they should all be null if they could be null and we should never return default values in models anymore like '' or 0, or whatever


![grafik](https://user-images.githubusercontent.com/15329494/215129052-4bd07d51-8d85-40c5-afec-b35d4e99f589.png)
![grafik](https://user-images.githubusercontent.com/15329494/215129115-db83abb9-cc26-4aaa-a1d4-ff4bab1f1c3d.png)
![grafik](https://user-images.githubusercontent.com/15329494/215129152-f3ad0fe3-0eb9-45e5-8dbc-b8b151a376b1.png)
![grafik](https://user-images.githubusercontent.com/15329494/215129218-3dfc164b-ee77-486e-9166-5e08e2380654.png)



Fixes #852