### PR TITLE
Remove unnecessary usage of shrinkwrap: true

### DIFF
--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -40,7 +40,7 @@ class AppDescription extends StatelessWidget {
         padding: const EdgeInsets.only(top: 20),
         child: MarkdownBody(
           data: description,
-          shrinkWrap: true,
+          shrinkWrap: false,
           selectable: true,
           onTapLink: (text, href, title) =>
               href != null ? launchUrl(Uri.parse(href)) : null,

--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -31,7 +31,7 @@ class AdditionalInformation extends StatelessWidget {
         child: ScrollConfiguration(
           behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
           child: GridView(
-            shrinkWrap: true,
+            shrinkWrap: false,
             physics: const NeverScrollableScrollPhysics(),
             gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
               maxCrossAxisExtent: 200,

--- a/lib/app/common/app_page/page_layouts.dart
+++ b/lib/app/common/app_page/page_layouts.dart
@@ -87,7 +87,6 @@ class OnePageLayout extends StatelessWidget {
               left: kPagePadding,
               right: kPagePadding,
             ),
-      shrinkWrap: true,
       children: [
         for (final child in children)
           Padding(

--- a/lib/app/common/app_page/page_layouts.dart
+++ b/lib/app/common/app_page/page_layouts.dart
@@ -87,6 +87,7 @@ class OnePageLayout extends StatelessWidget {
               left: kPagePadding,
               right: kPagePadding,
             ),
+      shrinkWrap: false,
       children: [
         for (final child in children)
           Padding(

--- a/lib/app/common/snap/snap_grid.dart
+++ b/lib/app/common/snap/snap_grid.dart
@@ -35,9 +35,13 @@ class SnapGrid extends StatelessWidget {
       return const SizedBox.shrink();
     }
     return GridView.builder(
-      padding: kGridPadding,
+      padding: const EdgeInsets.only(
+        bottom: 15,
+        right: 15,
+        left: 15,
+      ),
       gridDelegate: kGridDelegate,
-      shrinkWrap: true,
+      shrinkWrap: false,
       itemCount: snaps.length,
       itemBuilder: (context, index) {
         final snap = snaps.elementAt(index);

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -68,7 +68,7 @@ class SearchPage extends StatelessWidget {
                         left: 15,
                       ),
                       gridDelegate: kGridDelegate,
-                      shrinkWrap: true,
+                      shrinkWrap: false,
                       itemCount: snapshot.data!.length,
                       itemBuilder: (context, index) {
                         final appFinding =

--- a/lib/app/installed/installed_packages_page.dart
+++ b/lib/app/installed/installed_packages_page.dart
@@ -58,9 +58,13 @@ class _InstalledPackagesPageState extends State<InstalledPackagesPage> {
     return model.installedPackages.isNotEmpty
         ? GridView.builder(
             controller: _controller,
-            padding: kGridPadding,
+            padding: const EdgeInsets.only(
+              bottom: 15,
+              right: 15,
+              left: 15,
+            ),
             gridDelegate: kGridDelegate,
-            shrinkWrap: true,
+            shrinkWrap: false,
             itemCount: installedApps.length,
             itemBuilder: (context, index) {
               final package = installedApps[index];

--- a/lib/app/updates/update_dialog.dart
+++ b/lib/app/updates/update_dialog.dart
@@ -94,7 +94,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
           data: model.changelog.length > 4000
               ? '${model.changelog.substring(0, 4000)}\n\n ... ${context.l10n.changelogTooLong} ${model.url}'
               : model.changelog,
-          shrinkWrap: true,
+          shrinkWrap: false,
           selectable: true,
           onTapLink: (text, href, title) =>
               href != null ? launchUrl(Uri.parse(href)) : null,


### PR DESCRIPTION
As per the flutter documentation, making use of this property can lead to some performance issues due to the scrollView needing to be recomputed each time the scroll position changes. I tested this pretty thoroughly and didn't come across any issues.

The only place where I couldn't remove it was in the section_grid.dart and loading_banner_grid.dart files because they are nested inside a SingleChildScrollView. Optimally, we should make use of slivers in those cases but that would require a bit more refactoring.

Also fixes the bottom padding from 25 to 20 for the installed snaps and deb pages.

Before:
![Screenshot from 2023-01-27 19-45-12](https://user-images.githubusercontent.com/73116038/215183208-dd6912f9-932c-4552-a39b-7cc3ed50d607.png)

After:
![Screenshot from 2023-01-27 19-42-57](https://user-images.githubusercontent.com/73116038/215183233-0a9dcf7b-bc8c-4d39-9460-6065914a4753.png)

@Feichtmeier Since the default value of shrinkWrap is false, should I just remove all of the ```shrinkWrap: false,``` instances?

