### PR TITLE
Small styling fixes for dependecies popup

### DIFF
--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -292,29 +292,30 @@ class _ShowDepsDialogState extends State<_ShowDepsDialog> {
             ),
           ),
           YaruExpandable(
+            expandButtonPosition: YaruExpandableButtonPosition.start,
             onChange: (isExpanded) => setState(() => _isExpanded = isExpanded),
             header: MouseRegion(
               cursor: SystemMouseCursors.click,
               child: Text(
-                _isExpanded
-                    ? context.l10n.dependencies
-                    : context.l10n.dependenciesFullList,
+                context.l10n.dependencies,
                 style: TextStyle(
                   color: _isExpanded ? null : theme.primaryColor,
                   fontWeight: FontWeight.w500,
                 ),
               ),
             ),
-            child: Column(
-              children: [
-                for (var d in widget.dependencies)
-                  ListTile(
-                    title: Text(d),
-                    leading: const Icon(
-                      YaruIcons.package_deb,
-                    ),
-                  )
-              ],
+            child: BorderContainer(
+              child: Column(
+                children: [
+                  for (var d in widget.dependencies)
+                    ListTile(
+                      title: Text(d),
+                      leading: const Icon(
+                        YaruIcons.package_deb,
+                      ),
+                    )
+                ],
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
Very small improvements towards #739

- moved expander to start
- removed text changing (feels weird that the text changes when expanded)
- added border

As you can see there's still some issues. Just a placeholder until some advanced help (not me) arrives implementing [this idea 🖼️  ](https://github.com/ubuntu-flutter-community/software/issues/739#issuecomment-1399258699)

<img width="533px" src="https://user-images.githubusercontent.com/3986894/215334546-5c63a662-8424-4ab5-8a31-fa6b5514a12c.png">
