### PR TITLE
AppBanners: bring back correct BG colour in the light theme

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,10 +52,10 @@ dependencies:
   version: ^3.0.2
   window_manager: 0.3.0
   xdg_icons: ^0.0.1
-  yaru: ^0.5.0
+  yaru: ^0.5.1
   yaru_colors: ^0.1.1
   yaru_icons: ^1.0.2
-  yaru_widgets: ^2.0.0
+  yaru_widgets: ^2.0.1
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
Fixes a visual regression of appbanners being grey in the light theme, introduced by me in yaru.dart 0.5.0 and fixed by me in 0.5.1


|before|after|
|-|-|
|![grafik](https://user-images.githubusercontent.com/15329494/215490640-904c22dd-65cd-44da-bea0-25b814aafbe8.png)|![grafik](https://user-images.githubusercontent.com/15329494/215490520-9fb339dc-71e7-4523-9b1f-c61edd388129.png)|


Fixes #907