### PR TITLE
Improve search hint and avoid height jumping

### DIFF
--- a/integration_test/software_test.dart
+++ b/integration_test/software_test.dart
@@ -80,7 +80,8 @@ Future<void> testSearchPackage(
   WidgetTester tester, {
   required String packageName,
 }) async {
-  final searchField = find.widgetWithText(SearchField, tester.lang.searchHint);
+  final searchField =
+      find.widgetWithText(SearchField, tester.lang.searchHintAppStore);
   expectSync(searchField, findsOneWidget);
   await tester.enterText(searchField, packageName);
   await tester.pumpAndSettle();

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -103,18 +103,25 @@ class _SearchFieldState extends State<SearchField> {
                 prefixIconConstraints:
                     const BoxConstraints(minWidth: 40, minHeight: 0),
                 suffixIcon: widget.searchQuery.isNotEmpty
-                    ? IconButton(
-                        onPressed: _clear,
-                        icon: Center(
-                          child: Icon(
-                            YaruIcons.edit_clear,
-                            color: Theme.of(context).hintColor,
+                    ? SizedBox(
+                        height: 30,
+                        width: 30,
+                        child: Material(
+                          color: Colors.transparent,
+                          child: InkWell(
+                            onTap: _clear,
+                            child: Center(
+                              child: Icon(
+                                YaruIcons.edit_clear,
+                                color: Theme.of(context).hintColor,
+                              ),
+                            ),
                           ),
                         ),
                       )
                     : null,
                 suffixIconConstraints:
-                    const BoxConstraints(maxWidth: 35, maxHeight: 35),
+                    const BoxConstraints(maxWidth: 30, minHeight: 0),
                 isDense: true,
                 contentPadding: const EdgeInsets.all(8),
                 fillColor:

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -19,7 +19,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 class SearchField extends StatefulWidget {
@@ -28,11 +27,13 @@ class SearchField extends StatefulWidget {
     required this.searchQuery,
     required this.onChanged,
     this.autofocus = true,
+    this.hintText,
   });
 
   final String searchQuery;
   final Function(String value) onChanged;
   final bool autofocus;
+  final String? hintText;
 
   @override
   State<SearchField> createState() => _SearchFieldState();
@@ -94,7 +95,7 @@ class _SearchFieldState extends State<SearchField> {
               textInputAction: TextInputAction.send,
               decoration: InputDecoration(
                 filled: true,
-                hintText: context.l10n.searchHint,
+                hintText: widget.hintText,
                 prefixIcon: const Icon(
                   YaruIcons.search,
                   size: 15,

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -102,6 +102,7 @@ class _ExplorePageState extends State<ExplorePage> {
           key: ValueKey(showSearchPage),
           searchQuery: searchQuery,
           onChanged: setSearchQuery,
+          hintText: context.l10n.searchHintAppStore,
         ),
       ),
       body: !connectivity.isOnline

--- a/lib/app/installed/installed_page.dart
+++ b/lib/app/installed/installed_page.dart
@@ -87,6 +87,7 @@ class InstalledPage extends StatelessWidget {
         title: SearchField(
           searchQuery: searchQuery ?? '',
           onChanged: setSearchQuery,
+          hintText: context.l10n.searchHintInstalled,
         ),
       ),
       body: page,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -77,6 +77,8 @@
   "done": "Done",
   "updates": "Updates",
   "searchHint": "Search",
+  "searchHintAppStore": "Search for apps",
+  "searchHintInstalled": "Search your installed apps",
   "updateSelected": "Update selected",
   "selectAll": "Select all",
   "allSelected": "All updates selected",


### PR DESCRIPTION
- adds search hints for explore and installed as decided with the other designers
- use a custom close button to avoid height jumping as suffix icon

![grafik](https://user-images.githubusercontent.com/15329494/215543264-2173901f-ef5e-4ac7-a562-1915cedadc71.png)
![grafik](https://user-images.githubusercontent.com/15329494/215543311-8d83cab9-cbb2-48ea-b059-4dec8cdc0460.png)

![grafik](https://user-images.githubusercontent.com/15329494/215545570-d16b203c-8f56-44cd-8346-ea8ab362d217.png)


Fixes #854