### PR TITLE
WIP: search field on `AppPage`

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -39,6 +39,8 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'explore/explore_model.dart';
+
 class App extends StatelessWidget {
   const App({super.key});
 
@@ -54,6 +56,13 @@ class App extends StatelessWidget {
           ),
           ChangeNotifierProvider(
             create: (_) => ConnectivityNotifier(getService<Connectivity>()),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => ExploreModel(
+              getService<AppstreamService>(),
+              getService<SnapService>(),
+              getService<PackageService>(),
+            )..init(),
           ),
         ],
         child: const App(),

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:software/app/common/app_data.dart';
 import 'package:software/app/common/app_page/app_description.dart';
 import 'package:software/app/common/app_page/app_header.dart';
@@ -29,6 +30,8 @@ import 'package:software/app/common/app_page/page_layouts.dart';
 import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/custom_back_button.dart';
 import 'package:software/app/common/safe_network_image.dart';
+import 'package:software/app/common/search_field.dart';
+import 'package:software/app/explore/explore_model.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -257,10 +260,16 @@ class _AppPageState extends State<AppPage> {
             ? normalWindowLayout
             : narrowWindowLayout;
 
+    final searchQuery = context.select((ExploreModel m) => m.searchQuery);
+    final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
+
     return Scaffold(
       appBar: YaruWindowTitleBar(
-        title: Text(widget.appData.title),
-        titleSpacing: 0,
+        title: SearchField(
+          searchQuery: searchQuery,
+          onChanged: setSearchQuery,
+          onSubmitted: Navigator.of(context).pop,
+        ),
         leading: const CustomBackButton(),
       ),
       body: BackGesture(

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -26,12 +26,14 @@ class SearchField extends StatefulWidget {
     super.key,
     required this.searchQuery,
     required this.onChanged,
+    this.onSubmitted,
     this.autofocus = true,
     this.hintText,
   });
 
   final String searchQuery;
   final Function(String value) onChanged;
+  final VoidCallback? onSubmitted;
   final bool autofocus;
   final String? hintText;
 
@@ -93,6 +95,10 @@ class _SearchFieldState extends State<SearchField> {
               controller: _controller,
               onChanged: onChanged,
               textInputAction: TextInputAction.send,
+              onSubmitted: (value) {
+                widget.onChanged(value);
+                widget.onSubmitted?.call();
+              },
               decoration: InputDecoration(
                 filled: true,
                 hintText: widget.hintText,

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -83,11 +83,12 @@ class _ExplorePageState extends State<ExplorePage> {
     final showSearchPage = context.select((ExploreModel m) => m.showSearchPage);
     final searchQuery = context.select((ExploreModel m) => m.searchQuery);
     final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
-
+    final isCurrent = ModalRoute.of(context)?.isCurrent ?? false;
     return Scaffold(
       appBar: YaruWindowTitleBar(
         title: SearchField(
-          key: ValueKey(showSearchPage),
+          autofocus: isCurrent,
+          key: ValueKey(showSearchPage != isCurrent),
           searchQuery: searchQuery,
           onChanged: setSearchQuery,
           hintText: context.l10n.searchHintAppStore,

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -28,10 +28,6 @@ import 'package:software/app/explore/offline_page.dart';
 import 'package:software/app/explore/search_page.dart';
 import 'package:software/app/explore/start_page.dart';
 import 'package:software/l10n/l10n.dart';
-import 'package:software/services/appstream/appstream_service.dart';
-import 'package:software/services/packagekit/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -42,15 +38,7 @@ class ExplorePage extends StatefulWidget {
     BuildContext context, [
     String? errorMessage,
   ]) {
-    return ChangeNotifierProvider(
-      create: (_) => ExploreModel(
-        getService<AppstreamService>(),
-        getService<SnapService>(),
-        getService<PackageService>(),
-        errorMessage,
-      )..init(),
-      child: const ExplorePage(),
-    );
+    return const ExplorePage();
   }
 
   static Widget createTitle(BuildContext context) =>


### PR DESCRIPTION
* Adds a search field linked to the `ExploreModel` to `AppPage`
* Only works if `AppPage` is reached from the `ExplorePage`
* Unclear: search behavior on `AppPage`s of locally installed packages (and pages reached through a `snap://` link or by opening a local .deb file). In those cases, starting a search for new packages in the `ExplorePage` would be confusing. Options:
  - Perform search in the given context (i.e. search for installed packages when viewing the `AppPage` of a locally installed package). Might also be confusing unless there is a clearer (visual) distinction between `AppPage`s for local packages and packages from the store / repository.
  - Only show the search field on `AppPages` packages that aren't installed

Ref #855 