### PR TITLE
Refactor: separate app data and ratings

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -26,6 +26,7 @@ import 'package:software/app/app_splash_screen.dart';
 import 'package:software/app/common/close_confirmation_dialog.dart';
 import 'package:software/app/common/connectivity_notifier.dart';
 import 'package:software/app/common/page_item.dart';
+import 'package:software/app/common/rating_model.dart';
 import 'package:software/app/explore/explore_page.dart';
 import 'package:software/app/installed/installed_page.dart';
 import 'package:software/app/package_installer/package_installer_page.dart';
@@ -54,6 +55,9 @@ class App extends StatelessWidget {
           ),
           ChangeNotifierProvider(
             create: (_) => ConnectivityNotifier(getService<Connectivity>()),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => RatingModel(),
           ),
         ],
         child: const App(),

--- a/lib/app/common/app_finding.dart
+++ b/lib/app/common/app_finding.dart
@@ -4,13 +4,9 @@ import 'package:snapd/snapd.dart';
 class AppFinding {
   final Snap? snap;
   final AppstreamComponent? appstream;
-  final double? rating;
-  final int? totalRatings;
 
   AppFinding({
     this.snap,
     this.appstream,
-    this.rating,
-    this.totalRatings,
   });
 }

--- a/lib/app/common/app_rating.dart
+++ b/lib/app/common/app_rating.dart
@@ -1,0 +1,20 @@
+import 'package:appstream/appstream.dart';
+import 'package:snapd/snapd.dart';
+
+class AppRating {
+  final double? average;
+  final int? total;
+
+  AppRating({
+    this.average,
+    this.total,
+  });
+}
+
+extension SnapRatingId on Snap {
+  String get ratingId => 'io.snapcraft.$name-$id';
+}
+
+extension AppstreamRatingId on AppstreamComponent {
+  String get ratingId => '$package.desktop';
+}

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -25,9 +25,11 @@ import 'package:software/app/common/app_format.dart';
 import 'package:software/app/common/app_icon.dart';
 import 'package:software/app/common/app_page/app_format_toggle_buttons.dart';
 import 'package:software/app/common/app_page/app_page.dart';
+import 'package:software/app/common/app_rating.dart';
 import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/packagekit/package_controls.dart';
 import 'package:software/app/common/packagekit/package_model.dart';
+import 'package:software/app/common/rating_model.dart';
 import 'package:software/app/common/snap/snap_page.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/appstream/appstream_utils.dart';
@@ -126,6 +128,10 @@ class _PackagePageState extends State<PackagePage> {
   Widget build(BuildContext context) {
     final model = context.watch<PackageModel>();
     final theme = Theme.of(context);
+    final rating = model.appstream != null
+        ? context
+            .select((RatingModel m) => m.getRating(model.appstream!.ratingId))
+        : null;
 
     final appData = AppData(
       publisherName: model.developerName ?? context.l10n.unknown,
@@ -144,7 +150,7 @@ class _PackagePageState extends State<PackagePage> {
       screenShotUrls: model.screenshotUrls,
       description: model.description,
       userReviews: model.userReviews ?? [],
-      averageRating: model.averageRating ?? 0.0,
+      averageRating: rating?.average ?? 0.0,
       appFormat: AppFormat.packageKit,
       versionChanged: model.versionChanged ?? false,
       contact: context.l10n.unknown,

--- a/lib/app/common/rating_model.dart
+++ b/lib/app/common/rating_model.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:software/app/common/app_rating.dart';
+
+class RatingModel extends SafeChangeNotifier {
+  RatingModel();
+
+  final Map<String, AppRating?> _ratings = {};
+
+  AppRating? getRating(String appId) {
+    if (!_ratings.containsKey(appId)) {
+      _ratings[appId] = null;
+      Future.delayed(fakeDelay()).then((value) {
+        _ratings[appId] = AppRating(
+          average: fakeRating(),
+          total: fakeTotalRatings(),
+        );
+        notifyListeners();
+      });
+    }
+    return _ratings[appId];
+  }
+
+  double fakeRating() => 4.5;
+  int fakeTotalRatings() => Random().nextInt(3000);
+  Duration fakeDelay() => Duration(milliseconds: Random().nextInt(100));
+}

--- a/lib/app/common/snap/snap_grid.dart
+++ b/lib/app/common/snap/snap_grid.dart
@@ -15,8 +15,6 @@
  *
  */
 
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/common/app_finding.dart';
@@ -44,11 +42,7 @@ class SnapGrid extends StatelessWidget {
         return AppBanner(
           appFinding: MapEntry<String, AppFinding>(
             snap.name,
-            AppFinding(
-              snap: snap,
-              rating: 4.5,
-              totalRatings: Random().nextInt(3000),
-            ),
+            AppFinding(snap: snap),
           ),
           showSnap: true,
           showPackageKit: false,

--- a/lib/app/common/snap/snap_page.dart
+++ b/lib/app/common/snap/snap_page.dart
@@ -25,8 +25,10 @@ import 'package:software/app/common/app_format.dart';
 import 'package:software/app/common/app_icon.dart';
 import 'package:software/app/common/app_page/app_format_toggle_buttons.dart';
 import 'package:software/app/common/app_page/app_page.dart';
+import 'package:software/app/common/app_rating.dart';
 import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/packagekit/package_page.dart';
+import 'package:software/app/common/rating_model.dart';
 import 'package:software/app/common/snap/snap_connections_button.dart';
 import 'package:software/app/common/snap/snap_connections_dialog.dart';
 import 'package:software/app/common/snap/snap_controls.dart';
@@ -99,6 +101,8 @@ class _SnapPageState extends State<SnapPage> {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<SnapModel>();
+    final rating =
+        context.select((RatingModel m) => m.getRating(widget.snap.ratingId));
 
     final appData = AppData(
       releasedAt: model.selectedChannelReleasedAt,
@@ -123,7 +127,7 @@ class _SnapPageState extends State<SnapPage> {
           model.selectableChannels[model.channelToBeInstalled]?.version !=
               model.version,
       userReviews: model.userReviews ?? [],
-      averageRating: model.averageRating ?? 0.0,
+      averageRating: rating?.average ?? 0.0,
       appFormat: AppFormat.snap,
       contact: model.contact ?? context.l10n.unknown,
     );

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -16,7 +16,6 @@
  */
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:appstream/appstream.dart';
 import 'package:collection/collection.dart';
@@ -206,11 +205,7 @@ class ExploreModel extends SafeChangeNotifier {
       for (final snap in snaps) {
         appFindings.putIfAbsent(
           snap.name,
-          () => AppFinding(
-            snap: snap,
-            rating: fakeRating(),
-            totalRatings: fakeTotalRatings(),
-          ),
+          () => AppFinding(snap: snap),
         );
       }
 
@@ -221,13 +216,7 @@ class ExploreModel extends SafeChangeNotifier {
         if (snap == null) {
           appFindings.putIfAbsent(
             component.localizedName(),
-            () {
-              return AppFinding(
-                appstream: component,
-                rating: fakeRating(),
-                totalRatings: fakeTotalRatings(),
-              );
-            },
+            () => AppFinding(appstream: component),
           );
         } else {
           appFindings.update(
@@ -235,8 +224,6 @@ class ExploreModel extends SafeChangeNotifier {
             (value) => AppFinding(
               snap: snap,
               appstream: component,
-              rating: fakeRating(),
-              totalRatings: fakeTotalRatings(),
             ),
           );
         }
@@ -247,11 +234,7 @@ class ExploreModel extends SafeChangeNotifier {
       for (final snap in snaps) {
         appFindings.putIfAbsent(
           snap.name,
-          () => AppFinding(
-            snap: snap,
-            rating: fakeRating(),
-            totalRatings: fakeTotalRatings(),
-          ),
+          () => AppFinding(snap: snap),
         );
       }
     } else if (!selectedAppFormats.contains(AppFormat.snap) &&
@@ -260,19 +243,11 @@ class ExploreModel extends SafeChangeNotifier {
       for (final component in components) {
         appFindings.putIfAbsent(
           component.localizedName(),
-          () => AppFinding(
-            appstream: component,
-            rating: fakeRating(),
-            totalRatings: fakeTotalRatings(),
-          ),
+          () => AppFinding(appstream: component),
         );
       }
     }
 
     return appFindings;
   }
-
-  int fakeTotalRatings() => Random().nextInt(3000);
-
-  double fakeRating() => 4.5;
 }

--- a/lib/app/explore/section_grid.dart
+++ b/lib/app/explore/section_grid.dart
@@ -64,11 +64,7 @@ class SectionGrid extends StatelessWidget {
         return AppBanner(
           appFinding: MapEntry<String, AppFinding>(
             snap.name,
-            AppFinding(
-              snap: snap,
-              rating: 4.5,
-              totalRatings: 234,
-            ),
+            AppFinding(snap: snap),
           ),
           showSnap: true,
           showPackageKit: false,


### PR DESCRIPTION
Decouple app data and associated ratings because the latter comes from a different (potentially slow and unreliable) data source. We must be able to present apps in the GUI without waiting for ratings to arrive.

Ref: #872