### PR TITLE
Restructure UI and models

### DIFF
--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -27,7 +27,6 @@ import 'package:software/app/common/app_page/app_swipe_gesture.dart';
 import 'package:software/app/common/app_page/media_tile.dart';
 import 'package:software/app/common/app_page/page_layouts.dart';
 import 'package:software/app/common/border_container.dart';
-import 'package:software/app/common/custom_back_button.dart';
 import 'package:software/app/common/safe_network_image.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -258,11 +257,6 @@ class _AppPageState extends State<AppPage> {
             : narrowWindowLayout;
 
     return Scaffold(
-      appBar: YaruWindowTitleBar(
-        title: Text(widget.appData.title),
-        titleSpacing: 0,
-        leading: const CustomBackButton(),
-      ),
       body: BackGesture(
         child: body,
       ),

--- a/lib/app/common/search_field.dart
+++ b/lib/app/common/search_field.dart
@@ -28,10 +28,14 @@ class SearchField extends StatefulWidget {
     required this.onChanged,
     this.autofocus = true,
     this.hintText,
+    this.onSubmitted,
+    this.clear,
   });
 
   final String? searchQuery;
   final Function(String value) onChanged;
+  final void Function(String?)? onSubmitted;
+  final void Function()? clear;
   final bool autofocus;
   final String? hintText;
 
@@ -80,7 +84,11 @@ class _SearchFieldState extends State<SearchField> {
     return KeyboardListener(
       onKeyEvent: (value) {
         if (value.logicalKey == LogicalKeyboardKey.escape) {
-          _clear();
+          if (widget.clear != null) {
+            widget.clear!();
+          } else {
+            _clear();
+          }
         }
       },
       focusNode: FocusNode(),
@@ -94,6 +102,7 @@ class _SearchFieldState extends State<SearchField> {
               autofocus: widget.autofocus,
               controller: _controller,
               onChanged: onChanged,
+              onSubmitted: widget.onSubmitted,
               textInputAction: TextInputAction.send,
               decoration: InputDecoration(
                 filled: true,
@@ -112,7 +121,7 @@ class _SearchFieldState extends State<SearchField> {
                             child: Material(
                               color: Colors.transparent,
                               child: InkWell(
-                                onTap: _clear,
+                                onTap: widget.clear ?? _clear,
                                 child: Center(
                                   child: Icon(
                                     YaruIcons.edit_clear,

--- a/lib/app/explore/explore_error_page.dart
+++ b/lib/app/explore/explore_error_page.dart
@@ -1,15 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:software/app/explore/explore_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class ExploreErrorPage extends StatelessWidget {
-  const ExploreErrorPage({super.key});
+  const ExploreErrorPage({super.key, required this.errorMessage});
+
+  final String errorMessage;
 
   @override
   Widget build(BuildContext context) {
-    final errorMessage = context.select((ExploreModel m) => m.errorMessage);
-
     return ListView(
       padding: const EdgeInsets.all(kYaruPagePadding),
       children: [
@@ -17,7 +15,7 @@ class ExploreErrorPage extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SelectableText(
-              errorMessage ?? '',
+              errorMessage,
               style: const TextStyle(
                 fontSize: 15,
               ),

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -22,39 +22,19 @@ import 'package:provider/provider.dart';
 import 'package:software/app/app_model.dart';
 import 'package:software/app/common/app_format.dart';
 import 'package:software/app/common/connectivity_notifier.dart';
-import 'package:software/app/common/search_field.dart';
 import 'package:software/app/common/snap/snap_section.dart';
 import 'package:software/app/explore/explore_error_page.dart';
 import 'package:software/app/explore/explore_header.dart';
-import 'package:software/app/explore/explore_model.dart';
 import 'package:software/app/explore/offline_page.dart';
 import 'package:software/app/explore/search_page.dart';
 import 'package:software/app/explore/start_page.dart';
 import 'package:software/l10n/l10n.dart';
-import 'package:software/services/appstream/appstream_service.dart';
-import 'package:software/services/packagekit/package_service.dart';
-import 'package:software/services/snap_service.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 class ExplorePage extends StatefulWidget {
-  const ExplorePage({super.key});
-
-  static Widget create(
-    BuildContext context, [
-    String? errorMessage,
-  ]) {
-    return ChangeNotifierProvider(
-      create: (_) => ExploreModel(
-        getService<AppstreamService>(),
-        getService<SnapService>(),
-        getService<PackageService>(),
-        errorMessage,
-      )..init(),
-      child: const ExplorePage(),
-    );
-  }
+  const ExplorePage({
+    super.key,
+  });
 
   static Widget createTitle(BuildContext context) =>
       Text(context.l10n.explorePageTitle);
@@ -76,11 +56,10 @@ class _ExplorePageState extends State<ExplorePage> {
   @override
   void initState() {
     super.initState();
-    final model = context.read<ExploreModel>();
-    _sidebarEventListener = context
-        .read<AppModel>()
-        .sidebarEvents
-        .listen((_) => model.setSearchQuery(''));
+    final model = context.read<AppModel>();
+    _sidebarEventListener = model.sidebarEvents.listen((_) {
+      model.setSearchActive(false);
+    });
     final connectivity = context.read<ConnectivityNotifier>();
     connectivity.init();
   }
@@ -94,73 +73,57 @@ class _ExplorePageState extends State<ExplorePage> {
   @override
   Widget build(BuildContext context) {
     final connectivity = context.watch<ConnectivityNotifier>();
-    final showErrorPage = context.select((ExploreModel m) => m.showErrorPage);
-    final showSearchPage = context.select((ExploreModel m) => m.showSearchPage);
-    final searchQuery = context.select((ExploreModel m) => m.searchQuery);
-    final setSearchQuery = context.read<ExploreModel>().setSearchQuery;
-    final sectionSnapsAll = context.select((ExploreModel m) {
-      return m.sectionNameToSnapsMap[SnapSection.all];
-    });
     final selectedAppFormats =
-        context.select((ExploreModel m) => m.selectedAppFormats);
+        context.select((AppModel m) => m.selectedAppFormats);
     final enabledAppFormats =
-        context.select((ExploreModel m) => m.enabledAppFormats);
-    final selectedSection =
-        context.select((ExploreModel m) => m.selectedSection);
+        context.select((AppModel m) => m.enabledAppFormats);
+    final selectedSection = context.select((AppModel m) => m.selectedSection);
     final setSelectedSection =
-        context.select((ExploreModel m) => m.setSelectedSection);
-    final handleAppFormat =
-        context.select((ExploreModel m) => m.handleAppFormat);
-
+        context.select((AppModel m) => m.setSelectedSection);
+    final handleAppFormat = context.select((AppModel m) => m.handleAppFormat);
     final showSnap = context.select(
-      (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.snap),
+      (AppModel m) => m.selectedAppFormats.contains(AppFormat.snap),
     );
     final showPackageKit = context.select(
-      (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.packageKit),
+      (AppModel m) => m.selectedAppFormats.contains(AppFormat.packageKit),
     );
+    final searchResult = context.select((AppModel m) => m.searchResult);
 
-    final searchResult = context.select((ExploreModel m) => m.searchResult);
-    final search = context.select((ExploreModel m) => m.search);
+    final errorMessage = context.select((AppModel m) => m.errorMessage);
+    final sectionSnapsAll = context.select((AppModel m) {
+      return m.sectionNameToSnapsMap[SnapSection.all];
+    });
+    final search = context.select((AppModel m) => m.search);
+    final searchActive = context.select((AppModel m) => m.searchActive);
 
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        title: SearchField(
-          key: ValueKey(showSearchPage),
-          searchQuery: searchQuery,
-          onChanged: (value) {
-            setSearchQuery(value);
-            search();
-          },
-          hintText: context.l10n.searchHintAppStore,
-        ),
-      ),
-      body: !connectivity.isOnline
-          ? const OfflinePage()
-          : showErrorPage
-              ? const ExploreErrorPage()
-              : (showSearchPage
-                  ? SearchPage(
-                      searchResult: searchResult,
-                      showPackageKit: showPackageKit,
-                      showSnap: showSnap,
-                      header: ExploreHeader(
-                        selectedSection: selectedSection,
-                        enabledAppFormats: enabledAppFormats,
-                        selectedAppFormats: selectedAppFormats,
-                        handleAppFormat: (appFormat) {
-                          handleAppFormat(appFormat);
-                          search();
-                        },
-                        setSelectedSection: (value) {
-                          setSelectedSection(value);
-                          search();
-                        },
-                      ),
-                    )
-                  : StartPage(
-                      snaps: sectionSnapsAll,
-                      snapSection: SnapSection.all,
-                    )),
-    );
+    return !connectivity.isOnline
+        ? const OfflinePage()
+        : errorMessage != null && errorMessage.isNotEmpty
+            ? ExploreErrorPage(
+                errorMessage: errorMessage,
+              )
+            : searchActive == true
+                ? SearchPage(
+                    searchResult: searchResult,
+                    showPackageKit: showPackageKit,
+                    showSnap: showSnap,
+                    header: ExploreHeader(
+                      selectedSection: selectedSection,
+                      selectedAppFormats: selectedAppFormats,
+                      enabledAppFormats: enabledAppFormats,
+                      setSelectedSection: (value) {
+                        setSelectedSection(value);
+                        search();
+                      },
+                      handleAppFormat: (appFormat) {
+                        handleAppFormat(appFormat);
+                        search();
+                      },
+                    ),
+                  )
+                : StartPage(
+                    snaps: sectionSnapsAll,
+                    snapSection: SnapSection.all,
+                  );
   }
 }

--- a/lib/app/installed/installed_page.dart
+++ b/lib/app/installed/installed_page.dart
@@ -21,7 +21,6 @@ import 'package:provider/provider.dart';
 import 'package:software/app/common/app_format.dart';
 import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/indeterminate_circular_progress_icon.dart';
-import 'package:software/app/common/search_field.dart';
 import 'package:software/app/installed/installed_header.dart';
 import 'package:software/app/installed/installed_model.dart';
 import 'package:software/app/installed/installed_packages_page.dart';
@@ -31,7 +30,6 @@ import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 class InstalledPage extends StatelessWidget {
   const InstalledPage({super.key});
@@ -67,11 +65,11 @@ class InstalledPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final searchQuery = context.select((InstalledModel m) => m.searchQuery);
+    // final searchQuery = context.select((InstalledModel m) => m.searchQuery);
     final appFormat = context.select((InstalledModel m) => m.appFormat);
     final setAppFormat = context.select((InstalledModel m) => m.setAppFormat);
-    final setSearchQuery =
-        context.select((InstalledModel m) => m.setSearchQuery);
+    // final setSearchQuery =
+    //     context.select((InstalledModel m) => m.setSearchQuery);
     final enabledAppFormats =
         context.select((InstalledModel m) => m.enabledAppFormats);
     final loadSnapsWithUpdates =
@@ -84,7 +82,7 @@ class InstalledPage extends StatelessWidget {
     final snapSort = context.select((InstalledModel m) => m.snapSort);
     final setSnapSort = context.select((InstalledModel m) => m.setSnapSort);
 
-    final page = Column(
+    return Column(
       children: [
         InstalledHeader(
           appFormat: appFormat,
@@ -102,17 +100,6 @@ class InstalledPage extends StatelessWidget {
         else if (appFormat == AppFormat.packageKit)
           const Expanded(child: InstalledPackagesPage()),
       ],
-    );
-
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        title: SearchField(
-          searchQuery: searchQuery ?? '',
-          onChanged: setSearchQuery,
-          hintText: context.l10n.searchHintInstalled,
-        ),
-      ),
-      body: page,
     );
   }
 }

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -61,22 +61,17 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        title: Text(context.l10n.settingsPageTitle),
-      ),
-      body: ListView(
-        children: [
-          const ThemeSection(),
-          YaruSection(
-            margin: const EdgeInsets.all(kYaruPagePadding),
-            //width: kMinSectionWidth,
-            child: Column(
-              children: [_RepoTile.create(context), const _AboutTile()],
-            ),
-          )
-        ],
-      ),
+    return ListView(
+      children: [
+        const ThemeSection(),
+        YaruSection(
+          margin: const EdgeInsets.all(kYaruPagePadding),
+          //width: kMinSectionWidth,
+          child: Column(
+            children: [_RepoTile.create(context), const _AboutTile()],
+          ),
+        )
+      ],
     );
   }
 }

--- a/lib/app/updates/updates_page.dart
+++ b/lib/app/updates/updates_page.dart
@@ -12,7 +12,6 @@ import 'package:software/l10n/l10n.dart';
 import 'package:software/services/packagekit/package_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
 class UpdatesPage extends StatefulWidget {
   const UpdatesPage({
@@ -76,21 +75,15 @@ class _UpdatesPageState extends State<UpdatesPage>
       enabledAppFormats: model.enabledAppFormats,
     );
 
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        titleSpacing: 0,
-        title: Text(context.l10n.updates),
-      ),
-      body: model.appFormat == AppFormat.packageKit
-          ? PackageUpdatesPage.create(
-              context: context,
-              appFormatPopup: appFormatPopup,
-            )
-          : SnapUpdatesPage.create(
-              context: context,
-              appFormatPopup: appFormatPopup,
-            ),
-    );
+    return model.appFormat == AppFormat.packageKit
+        ? PackageUpdatesPage.create(
+            context: context,
+            appFormatPopup: appFormatPopup,
+          )
+        : SnapUpdatesPage.create(
+            context: context,
+            appFormatPopup: appFormatPopup,
+          );
   }
 }
 


### PR DESCRIPTION
- move search from explore model to app model
- pass search results down from app model
- select values from app model in search and explore page
- use the yaruwindowtitlebar above the yarunavigationpage
- remove yaruwindowtitlebars in the child pages

Fixes #922
Fixes #921