### PR TITLE
snap: use flutter 3.7.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@ assumes:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.3.10
+    source-tag: 3.7.0
     plugin: nil
     override-build: |
       set -eux
@@ -29,8 +29,6 @@ parts:
       ln -sf $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $CRAFT_PART_INSTALL/usr/bin/flutter
       export PATH="$CRAFT_PART_INSTALL/usr/bin:$PATH"
       flutter doctor
-      flutter channel stable
-      flutter upgrade
     build-packages:
       - clang
       - cmake


### PR DESCRIPTION
We're specifying `source-tag: 3.3.10` but then executing `flutter channel stable` followed by `flutter upgrade` which means we're actually using the very latest stable release.

Yaru and friends required 3.7.0 these days, so use that because our arm64 build is currently broken, which could be related to 3.7.1?

```
: [        ] [  +23 ms] Target release_bundle_linux-arm64_assets failed: ShaderCompilerException: Shader compilation of "/build/snap-store/parts/flutter-git/install/usr/libexec/flutter/packages/flutter/lib/src/material/shaders/ink_sparkle.frag" to "/build/snap-store/parts/software/build/build/flutter_assets/shaders/ink_sparkle.frag" failed with exit code 1.
:: [        ]            impellerc stdout:
:: [        ]            impellerc stderr:
:: [        ]            Compilation to SkSL failed.
:: [        ]            /build/snap-store/parts/flutter-git/install/usr/libexec/flutter/packages/flutter/lib/src/material/shaders/ink_sparkle.frag: GLSL to SPIRV failed; Compilation error. 3 error(s) and 1 warning(s).
:: [        ]            /build/snap-store/parts/flutter-git/install/usr/libexec/flutter/packages/flutter/lib/src/material/shaders/ink_sparkle.frag: warning: (version, profile) forced to be (460, core), while in source code it is (320, es)
:: [        ]            /build/snap-store/parts/flutter-git/install/usr/libexec/flutter/packages/flutter/lib/src/material/shaders/ink_sparkle.frag:9: error: '#include' : Included file not found. for header name: flutter/runtime_effect.glsl
:: [        ]            /build/snap-store/parts/flutter-git/install/usr/libexec/flutter/packages/flutter/lib/src/material/shaders/ink_sparkle.frag:93: error: 'FlutterFragCoord' : no matching overloaded function found
:: [        ]            /build/snap-store/parts/flutter-git/install/usr/libexec/flutter/packages/flutter/lib/src/material/shaders/ink_sparkle.frag:93: error: '=' :  cannot convert from ' const float' to ' temp 2-component vector of float'
```