### PR TITLE
Settings: move to trailing & open in dialog

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -240,14 +240,7 @@ class __AppState extends State<_App> {
               style: itemStyle,
               onTap: () => showDialog(
                 context: context,
-                builder: (context) => AlertDialog(
-                  title: YaruDialogTitleBar(
-                    title: SettingsPage.createTitle(context),
-                  ),
-                  titlePadding: EdgeInsets.zero,
-                  content:
-                      SizedBox(width: 600, child: SettingsPage.create(context)),
-                ),
+                builder: (context) => SettingsPage.create(context),
               ),
             ),
             leading: AnimatedContainer(

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -222,12 +222,6 @@ class __AppState extends State<_App> {
           iconBuilder: (context, selected) =>
               PackageInstallerPage.createIcon(context, selected),
         ),
-      PageItem(
-        titleBuilder: SettingsPage.createTitle,
-        builder: SettingsPage.create,
-        iconBuilder: (context, selected) =>
-            SettingsPage.createIcon(context, selected),
-      ),
     ];
 
     var normalWindowSize = width > 800 && width < 1200;
@@ -240,6 +234,22 @@ class __AppState extends State<_App> {
 
     return _initialized
         ? YaruNavigationPage(
+            trailing: YaruNavigationRailItem(
+              icon: SettingsPage.createIcon(context, false),
+              label: SettingsPage.createTitle(context),
+              style: itemStyle,
+              onTap: () => showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: YaruDialogTitleBar(
+                    title: SettingsPage.createTitle(context),
+                  ),
+                  titlePadding: EdgeInsets.zero,
+                  content:
+                      SizedBox(width: 600, child: SettingsPage.create(context)),
+                ),
+              ),
+            ),
             leading: AnimatedContainer(
               width: normalWindowSize
                   ? 100

--- a/lib/app/settings/repo_dialog.dart
+++ b/lib/app/settings/repo_dialog.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:software/app/common/message_bar.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/app/updates/package_updates_model.dart';
+import 'package:software/services/packagekit/package_service.dart';
 import 'package:software/services/packagekit/updates_state.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_session/ubuntu_session.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class RepoDialog extends StatefulWidget {
-  // ignore: unused_element
   const RepoDialog({super.key});
+
+  static Widget create(BuildContext context) {
+    return ChangeNotifierProvider<PackageUpdatesModel>(
+      create: (context) => PackageUpdatesModel(
+        getService<PackageService>(),
+        getService<UbuntuSession>(),
+      ),
+      child: const RepoDialog(),
+    );
+  }
 
   @override
   State<RepoDialog> createState() => _RepoDialogState();
@@ -17,10 +30,33 @@ class RepoDialog extends StatefulWidget {
 class _RepoDialogState extends State<RepoDialog> {
   late TextEditingController controller;
 
+  void showSnackBar() {
+    if (!mounted) return;
+    final model = context.read<PackageUpdatesModel>();
+    if (model.errorMessage.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          duration: const Duration(minutes: 1),
+          padding: EdgeInsets.zero,
+          content: MessageBar(
+            message: model.errorMessage,
+            copyMessage: context.l10n.copyErrorMessage,
+          ),
+        ),
+      );
+    }
+  }
+
+  bool _initialized = false;
   @override
   void initState() {
     super.initState();
     controller = TextEditingController();
+
+    context
+        .read<PackageUpdatesModel>()
+        .init(handleError: () => showSnackBar(), loadRepoList: true)
+        .then((_) => _initialized = true);
   }
 
   @override
@@ -33,56 +69,77 @@ class _RepoDialogState extends State<RepoDialog> {
   Widget build(BuildContext context) {
     final model = context.watch<PackageUpdatesModel>();
 
-    return SimpleDialog(
-      title: YaruDialogTitleBar(
-        title: model.updatesState != UpdatesState.updating &&
-                model.updatesState != UpdatesState.checkingForUpdates
-            ? Row(
-                children: [
-                  IconButton(
-                    onPressed:
-                        controller.text.isEmpty ? null : () => model.addRepo(),
-                    icon: const Icon(YaruIcons.plus),
-                  ),
-                  const SizedBox(
-                    width: 10,
-                  ),
-                  SizedBox(
-                    width: 300,
-                    child: TextField(
-                      onChanged: (value) => model.manualRepoName = value,
-                      controller: controller,
-                      decoration: InputDecoration(
-                        isDense: false,
-                        hintText: context.l10n.enterRepoName,
-                        border: const UnderlineInputBorder(),
-                        enabledBorder: const UnderlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                        ),
-                      ),
-                    ),
-                  )
-                ],
-              )
-            : const SizedBox(),
+    final ready = (model.updatesState != UpdatesState.updating &&
+            model.updatesState != UpdatesState.checkingForUpdates) &&
+        _initialized;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.background,
+        borderRadius: BorderRadius.circular(10),
       ),
-      titlePadding: EdgeInsets.zero,
-      children: model.repos
-          .map(
-            (e) => ListTile(
-              enabled: model.updatesState != UpdatesState.updating &&
-                  model.updatesState != UpdatesState.checkingForUpdates,
-              trailing: YaruCheckbox(
-                value: e.enabled,
-                onChanged: (v) => model.toggleRepo(id: e.repoId, value: v!),
-              ),
-              title: ListTile(
-                title: Text(e.repoId),
-                subtitle: Text(e.description),
-              ),
+      child: Column(
+        children: [
+          YaruDialogTitleBar(
+            leading: YaruBackButton(
+              style: YaruBackButtonStyle.rounded,
+              onPressed: () => Navigator.of(context).pop(),
             ),
-          )
-          .toList(),
+            title: ready
+                ? Row(
+                    children: [
+                      IconButton(
+                        onPressed: controller.text.isEmpty
+                            ? null
+                            : () => model.addRepo(),
+                        icon: const Icon(YaruIcons.plus),
+                      ),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      SizedBox(
+                        width: 300,
+                        height: 35,
+                        child: TextField(
+                          onChanged: (value) => model.manualRepoName = value,
+                          controller: controller,
+                          decoration: InputDecoration(
+                            isDense: false,
+                            hintText: context.l10n.enterRepoName,
+                          ),
+                        ),
+                      )
+                    ],
+                  )
+                : const SizedBox.shrink(),
+          ),
+          if (!ready)
+            const Expanded(
+              child: Center(child: YaruCircularProgressIndicator()),
+            )
+          else
+            Expanded(
+              child: ListView(
+                children: [
+                  for (final e in model.repos)
+                    ListTile(
+                      enabled: model.updatesState != UpdatesState.updating &&
+                          model.updatesState != UpdatesState.checkingForUpdates,
+                      trailing: YaruCheckbox(
+                        value: e.enabled,
+                        onChanged: (v) =>
+                            model.toggleRepo(id: e.repoId, value: v!),
+                      ),
+                      title: ListTile(
+                        title: Text(e.repoId),
+                        subtitle: Text(e.description),
+                      ),
+                    )
+                ],
+              ),
+            )
+        ],
+      ),
     );
   }
 }

--- a/lib/app/settings/repo_dialog.dart
+++ b/lib/app/settings/repo_dialog.dart
@@ -120,6 +120,10 @@ class _RepoDialogState extends State<RepoDialog> {
           else
             Expanded(
               child: ListView(
+                padding: const EdgeInsets.only(
+                  top: kYaruPagePadding,
+                  bottom: kYaruPagePadding,
+                ),
                 children: [
                   for (final e in model.repos)
                     ListTile(

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -268,88 +268,90 @@ class _AboutDialog extends StatelessWidget {
             ),
           ),
           Expanded(
-              child: ListView(
-            padding: const EdgeInsets.only(
-              top: kYaruPagePadding,
-              bottom: kYaruPagePadding,
-              left: 40,
-              right: 40,
-            ),
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Image.asset(
-                    'assets/software.png',
-                    width: 100,
-                    height: 100,
-                    filterQuality: FilterQuality.medium,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(10.0),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          model.appName,
-                          style: Theme.of(context).textTheme.headlineSmall,
-                        ),
-                        Text(
-                          '${context.l10n.version} ${model.version} ${model.buildNumber}',
-                        ),
-                        InkWell(
-                          borderRadius: BorderRadius.circular(5),
-                          onTap: () async =>
-                              await launchUrl(Uri.parse(repoUrl)),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                context.l10n.findOurRepository,
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .bodyMedium
-                                    ?.copyWith(
-                                      color:
-                                          Theme.of(context).colorScheme.primary,
-                                    ),
-                              ),
-                              const SizedBox(
-                                width: 5,
-                              ),
-                              Icon(
-                                YaruIcons.external_link,
-                                color: Theme.of(context).primaryColor,
-                                size: 18,
-                              )
-                            ],
-                          ),
-                        ),
-                      ],
+            child: ListView(
+              padding: const EdgeInsets.only(
+                top: kYaruPagePadding,
+                bottom: kYaruPagePadding,
+                left: 40,
+                right: 40,
+              ),
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Image.asset(
+                      'assets/software.png',
+                      width: 100,
+                      height: 100,
+                      filterQuality: FilterQuality.medium,
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(
-                height: 20,
-              ),
-              FutureBuilder<String>(
-                future: loadAsset(context),
-                builder: (context, snapshot) {
-                  if (snapshot.hasData) {
-                    return MarkdownBody(
-                      data: '${context.l10n.madeBy}:\n ${snapshot.data!}',
-                      onTapLink: (text, href, title) =>
-                          href != null ? launchUrl(Uri.parse(href)) : null,
-                    );
-                  } else {
-                    return const SizedBox();
-                  }
-                },
-              )
-            ],
-          ))
+                    Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            model.appName,
+                            style: Theme.of(context).textTheme.headlineSmall,
+                          ),
+                          Text(
+                            '${context.l10n.version} ${model.version} ${model.buildNumber}',
+                          ),
+                          InkWell(
+                            borderRadius: BorderRadius.circular(5),
+                            onTap: () async =>
+                                await launchUrl(Uri.parse(repoUrl)),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  context.l10n.findOurRepository,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodyMedium
+                                      ?.copyWith(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .primary,
+                                      ),
+                                ),
+                                const SizedBox(
+                                  width: 5,
+                                ),
+                                Icon(
+                                  YaruIcons.external_link,
+                                  color: Theme.of(context).primaryColor,
+                                  size: 18,
+                                )
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 20,
+                ),
+                FutureBuilder<String>(
+                  future: loadAsset(context),
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                      return MarkdownBody(
+                        data: '${context.l10n.madeBy}:\n ${snapshot.data!}',
+                        onTapLink: (text, href, title) =>
+                            href != null ? launchUrl(Uri.parse(href)) : null,
+                      );
+                    } else {
+                      return const SizedBox();
+                    }
+                  },
+                )
+              ],
+            ),
+          )
         ],
       ),
     );

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -89,6 +89,7 @@ class _SettingsPageState extends State<SettingsPage> {
     );
 
     return AlertDialog(
+      backgroundColor: Theme.of(context).colorScheme.background,
       titlePadding: EdgeInsets.zero,
       contentPadding: EdgeInsets.zero,
       content: SizedBox(height: 800, width: 600, child: nav),

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -117,10 +117,17 @@ class _SettingsPage extends StatelessWidget {
             children: [
               const ThemeSection(),
               YaruSection(
+                headline: Text(context.l10n.sources),
                 margin: const EdgeInsets.all(kYaruPagePadding),
                 child: Column(
-                  children: const [_RepoTile(), _AboutTile()],
+                  children: const [
+                    _RepoTile(),
+                  ],
                 ),
+              ),
+              const YaruSection(
+                margin: EdgeInsets.symmetric(horizontal: kYaruPagePadding),
+                child: _AboutTile(),
               )
             ],
           ),
@@ -215,7 +222,6 @@ class _RepoTileState extends State<_RepoTile> {
   Widget build(BuildContext context) {
     // final model = context.watch<PackageUpdatesModel>();
     return YaruTile(
-      title: Text(context.l10n.sources),
       subtitle: Text(context.l10n.sourcesDescription),
       trailing: OutlinedButton(
         onPressed: () =>
@@ -235,7 +241,7 @@ class _AboutTile extends StatelessWidget {
 
     return YaruTile(
       title: Text(
-        '${model.appName} ${model.version} ${model.buildNumber}',
+        '${context.l10n.version} ${model.version} ${model.buildNumber}',
       ),
       trailing: TextButton(
         onPressed: () => Utils.settingsNav.currentState!.pushNamed('/about'),

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -63,25 +63,19 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: YaruWindowTitleBar(
-        title: Text(context.l10n.settingsPageTitle),
-      ),
-      body: Center(
-        child: SizedBox(
-          width: 650,
-          child: ListView(
-            children: [
-              const ThemeSection(),
-              YaruSection(
-                margin: const EdgeInsets.all(kYaruPagePadding),
-                //width: kMinSectionWidth,
-                child: Column(
-                  children: [_RepoTile.create(context), const _AboutTile()],
-                ),
-              )
-            ],
-          ),
+    return Center(
+      child: SizedBox(
+        width: 650,
+        child: ListView(
+          children: [
+            const ThemeSection(),
+            YaruSection(
+              margin: const EdgeInsets.all(kYaruPagePadding),
+              child: Column(
+                children: [_RepoTile.create(context), const _AboutTile()],
+              ),
+            )
+          ],
         ),
       ),
     );


### PR DESCRIPTION
I think it would be better to open the settings page without the need to leave the current page.

Any veto @anasereijo @madsrh @Jupi007 @d-loose  or @jpnurmi ? :smile_cat: 

Edit: if we merge this I will change the other dialogs on this page to be inside the settings dialog instead of opening a new one

![grafik](https://user-images.githubusercontent.com/15329494/216611374-97eb79d4-d6c4-4bba-8051-d836a2a9125a.png)
![grafik](https://user-images.githubusercontent.com/15329494/216613037-e23f7eed-1733-4f78-b49e-715698690d5c.png)


