### PR TITLE
Changed font size for app_header

### DIFF
--- a/lib/app/common/app_page/app_header.dart
+++ b/lib/app/common/app_page/app_header.dart
@@ -65,7 +65,7 @@ class BannerAppHeader extends StatelessWidget {
                   children: [
                     Text(
                       appData.title,
-                      style: Theme.of(context).textTheme.titleLarge,
+                      style: theme.textTheme.titleLarge,
                     ),
                     PublisherName(
                       height: 14,

--- a/lib/app/common/app_page/app_header.dart
+++ b/lib/app/common/app_page/app_header.dart
@@ -65,13 +65,10 @@ class BannerAppHeader extends StatelessWidget {
                   children: [
                     Text(
                       appData.title,
-                      style: theme.textTheme.displaySmall!.copyWith(
-                        fontSize: 20,
-                        color: theme.colorScheme.onSurface,
-                      ),
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                     PublisherName(
-                      height: 18,
+                      height: 14,
                       publisherName: appData.publisherName,
                       website: appData.website,
                       verified: appData.verified,
@@ -149,7 +146,7 @@ class PageAppHeader extends StatelessWidget {
                   ),
                   Center(
                     child: PublisherName(
-                      height: 20,
+                      height: 14,
                       publisherName: appData.publisherName,
                       website: appData.website,
                       verified: appData.verified,


### PR DESCRIPTION
Use the same font weight as expander headlines. Not sure if using bold font here is the correct solution. WDYT? @Feichtmeier @Jupi007 

Fixes https://github.com/ubuntu-flutter-community/software/issues/962 

Also slightly smaller fontsize for the publishername.



![image](https://user-images.githubusercontent.com/3986894/216779153-ad8c004c-7216-42ae-839e-b9947860410c.png)
