### PR TITLE
LicensePage tweaks

### DIFF
--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -427,12 +427,7 @@ class _LicensePage extends StatelessWidget {
       ),
       child: Column(
         children: [
-          YaruDialogTitleBar(
-            leading: YaruBackButton(
-              style: YaruBackButtonStyle.rounded,
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-          ),
+          YaruDialogTitleBar(),
           Expanded(
             child: Theme(
               data: Theme.of(context).copyWith(
@@ -442,9 +437,6 @@ class _LicensePage extends StatelessWidget {
               child: const LicensePage(),
             ),
           ),
-          const SizedBox(
-            height: 20,
-          )
         ],
       ),
     );

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -427,7 +427,7 @@ class _LicensePage extends StatelessWidget {
       ),
       child: Column(
         children: [
-          YaruDialogTitleBar(),
+          const YaruDialogTitleBar(),
           Expanded(
             child: Theme(
               data: Theme.of(context).copyWith(

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -425,19 +425,25 @@ class _LicensePage extends StatelessWidget {
         color: Theme.of(context).colorScheme.background,
         borderRadius: BorderRadius.circular(10),
       ),
-      child: Column(
-        children: [
-          const YaruDialogTitleBar(),
-          Expanded(
-            child: Theme(
-              data: Theme.of(context).copyWith(
-                pageTransitionsTheme:
-                    YaruMasterDetailTheme.of(context).landscapeTransitions,
+      child: ClipRRect(
+        borderRadius: const BorderRadius.only(
+          bottomLeft: Radius.circular(8.0),
+          bottomRight: Radius.circular(8.0),
+        ),
+        child: Column(
+          children: [
+            const YaruDialogTitleBar(),
+            Expanded(
+              child: Theme(
+                data: Theme.of(context).copyWith(
+                  pageTransitionsTheme:
+                      YaruMasterDetailTheme.of(context).landscapeTransitions,
+                ),
+                child: const LicensePage(),
               ),
-              child: const LicensePage(),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Small tweaks for license page:

- Removed duplicate back button
- Use full window height (removed SizedBox)

Before:
![image](https://user-images.githubusercontent.com/3986894/216785747-e9946f24-3319-4baa-818f-fa79bf06e59f.png)


After:
![image](https://user-images.githubusercontent.com/3986894/216785751-18332538-c4b0-4823-ab53-111a4e1ae1d6.png)

