### PR TITLE
Attempt to fix occasional blank window

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -6,6 +6,8 @@ set(APPLICATION_ID "io.snapcraft.Store")
 
 cmake_policy(SET CMP0063 NEW)
 
+set(USE_LIBHANDY ON)
+
 set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 
 # Configure build options.

--- a/pubspec_overrides.yaml
+++ b/pubspec_overrides.yaml
@@ -1,0 +1,9 @@
+dependency_overrides:
+  handy_window:
+    git:
+      ref: main
+      url: https://github.com/ubuntu-flutter-community/handy_window
+  window_manager:
+    git:
+      ref: linux-hide-title
+      url: https://github.com/jpnurmi/window_manager


### PR DESCRIPTION
- Use `HdyWindow` directly from libhandy instead of relying on the widget tree restructuring magic by `handy_window`
- Restore the original order for showing the window and view, as it is in the Flutter app template

Probably fixes: #868