### PR TITLE
PackageService: remove filter in isInstalled

### DIFF
--- a/lib/services/packagekit/package_service.dart
+++ b/lib/services/packagekit/package_service.dart
@@ -484,7 +484,6 @@ class PackageService {
     });
     transaction.searchNames(
       [model.packageId!.name],
-      filter: {PackageKitFilter.installed},
     );
     return completer.future.whenComplete(subscription.cancel);
   }

--- a/test/services/package_service_test.dart
+++ b/test/services/package_service_test.dart
@@ -133,8 +133,7 @@ void main() {
     });
 
     when(
-      () => transaction
-          .searchNames(['firefox'], filter: {PackageKitFilter.installed}),
+      () => transaction.searchNames(['firefox']),
     ).thenAnswer((_) {
       controller.add(
         const PackageKitPackageEvent(


### PR DESCRIPTION
Uninstalled packages need to be included in the search to correctly determine whether a package is installed - otherwise it will find installed packages with a similar name, e.g. leftover dependencies like [packagename]-data.

Fix #976 