### PR TITLE
PackageService: fix isInstalled

### DIFF
--- a/lib/services/packagekit/package_service.dart
+++ b/lib/services/packagekit/package_service.dart
@@ -472,7 +472,8 @@ class PackageService {
     final transaction = await _client.createTransaction();
     final completer = Completer();
     final subscription = transaction.events.listen((event) {
-      if (event is PackageKitPackageEvent) {
+      if (event is PackageKitPackageEvent &&
+          model.packageId!.name == event.packageId.name) {
         model.isInstalled = event.info == PackageKitInfo.installed;
         model.versionChanged =
             event.packageId.version != model.packageId?.version;


### PR DESCRIPTION
Sorry, this needs another fix:
with multiple matches it reports the 'installed' status of the last package event, even if the name doesn't match.