### PR TITLE
Add dependency removal dialog

### DIFF
--- a/lib/app/common/packagekit/package_controls.dart
+++ b/lib/app/common/packagekit/package_controls.dart
@@ -29,7 +29,9 @@ class PackageControls extends StatelessWidget {
     required this.packageState,
     required this.versionChanged,
     this.hasDependencies,
-    this.showDeps,
+    this.hasMissingDependencies,
+    this.showDepsAndInstall,
+    this.showDepsAndRemove,
   });
 
   final bool? isInstalled;
@@ -38,7 +40,9 @@ class PackageControls extends StatelessWidget {
   final PackageState packageState;
   final bool? versionChanged;
   final bool? hasDependencies;
-  final VoidCallback? showDeps;
+  final bool? hasMissingDependencies;
+  final VoidCallback? showDepsAndInstall;
+  final VoidCallback? showDepsAndRemove;
 
   @override
   Widget build(BuildContext context) {
@@ -64,14 +68,20 @@ class PackageControls extends StatelessWidget {
           : [
               if (isInstalled == true)
                 OutlinedButton(
-                  onPressed: packageState != PackageState.ready ? null : remove,
+                  onPressed: packageState != PackageState.ready
+                      ? null
+                      : (hasDependencies ?? false
+                          ? showDepsAndRemove ?? remove
+                          : remove),
                   child: Text(context.l10n.remove),
                 ),
               if (isInstalled == false)
                 ElevatedButton(
                   onPressed: packageState != PackageState.ready
                       ? null
-                      : (hasDependencies == true ? showDeps : install),
+                      : (hasMissingDependencies == true
+                          ? showDepsAndInstall
+                          : install),
                   child: Text(context.l10n.install),
                 ),
               if (isInstalled == true && versionChanged == true)

--- a/lib/app/common/packagekit/package_model.dart
+++ b/lib/app/common/packagekit/package_model.dart
@@ -259,9 +259,9 @@ class PackageModel extends SafeChangeNotifier {
     }
   }
 
-  Future<void> remove() async {
+  Future<void> remove({dependencies = false}) async {
     return _service
-        .remove(model: this)
+        .remove(model: this, dependencies: dependencies)
         .then(_updateDetails)
         .then(_updatePercentage);
   }

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -32,6 +32,7 @@ import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/packagekit/package_controls.dart';
 import 'package:software/app/common/packagekit/package_model.dart';
 import 'package:software/app/common/rating_model.dart';
+import 'package:software/app/common/remove_deps_dialog.dart';
 import 'package:software/app/common/review_model.dart';
 import 'package:software/app/common/snap/snap_page.dart';
 import 'package:software/l10n/l10n.dart';
@@ -199,15 +200,23 @@ class _PackagePageState extends State<PackagePage> {
       isInstalled: model.isInstalled,
       versionChanged: model.versionChanged,
       packageState: model.packageState,
-      remove: () => model.remove(),
+      remove: model.remove,
       install: model.install,
-      hasDependencies: model.missingDependencies.isNotEmpty,
-      showDeps: () => showDialog(
+      hasDependencies: model.dependencies.isNotEmpty,
+      hasMissingDependencies: model.missingDependencies.isNotEmpty,
+      showDepsAndInstall: () => showDialog(
         context: context,
         builder: (context) => _ShowDepsDialog(
           packageName: model.title ?? context.l10n.unknown,
           onInstall: model.install,
           dependencies: model.missingDependencies,
+        ),
+      ),
+      showDepsAndRemove: () => showDialog(
+        context: context,
+        builder: (_) => RemoveDepsDialog(
+          removeDeps: () => model.remove(dependencies: true),
+          dontRemoveDeps: model.remove,
         ),
       ),
     );

--- a/lib/app/common/remove_deps_dialog.dart
+++ b/lib/app/common/remove_deps_dialog.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:software/l10n/l10n.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+class RemoveDepsDialog extends StatelessWidget {
+  const RemoveDepsDialog({super.key, this.removeDeps, this.dontRemoveDeps});
+
+  final VoidCallback? removeDeps;
+  final VoidCallback? dontRemoveDeps;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: SizedBox(
+        width: 500,
+        child: YaruDialogTitleBar(
+          title: Text(context.l10n.dependencies),
+        ),
+      ),
+      titlePadding: EdgeInsets.zero,
+      content: Text(context.l10n.dependencyRemovalChoice),
+      actions: [
+        OutlinedButton(
+          onPressed: () {
+            dontRemoveDeps?.call();
+            Navigator.pop(context);
+          },
+          child: Text(context.l10n.no),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            removeDeps?.call();
+            Navigator.of(context).pop();
+          },
+          child: Text(context.l10n.yes),
+        )
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -174,10 +174,13 @@
         }
     }
   },
+  "dependencyRemovalChoice": "Do you want to remove dependencies that are not needed any longer?",
   "gallery": "Gallery",
   "additionalInformation": "Additional Information",
   "links": "Links",
   "packagesUsed": "Packages used",
   "contributors": "Contributors",
-  "collection": "Collection"
+  "collection": "Collection",
+  "yes": "Yes",
+  "no": "No"
 }

--- a/lib/services/packagekit/package_service.dart
+++ b/lib/services/packagekit/package_service.dart
@@ -426,7 +426,10 @@ class PackageService {
     return completer.future.whenComplete(subscription.cancel);
   }
 
-  Future<void> remove({required PackageModel model}) async {
+  Future<void> remove({
+    required PackageModel model,
+    dependencies = false,
+  }) async {
     if (model.packageId == null) throw const MissingPackageIDException();
     model.packageState = PackageState.processing;
     final transaction = await _client.createTransaction();
@@ -442,7 +445,11 @@ class PackageService {
         completer.complete();
       }
     });
-    await transaction.removePackages([model.packageId!]);
+    await transaction.removePackages(
+      [model.packageId!],
+      allowDeps: dependencies,
+      autoremove: dependencies,
+    );
     await completer.future;
     await subscription.cancel();
     _installedPackages.remove(model.packageId!.name);


### PR DESCRIPTION
Adds a simple dialog, that allows removing unneeded dependencies when removing a deb.
![image](https://user-images.githubusercontent.com/113362648/217295377-7e913baf-56ea-4687-a927-acb3ec0142e6.png)

Possible improvements:
* Add this to the `CollectionPage` as well (@Feichtmeier I've seen that you've avoided calling `PackageModel.init` for the list tiles to reduce the number of unnecessary PackageKit queries. We'd need to know whether each of the packages have dependencies here, though. Maybe this could be done after clicking the 'remove' button - might need some refactoring.)
* Add more details about the dependencies to be removed. If I understand PackageKit correctly, it doesn't give us enough information about a package's dependencies to figure out whether or not they're needed by other packages as well, and thus wouldn't be automatically removed. Calling PackageKit's `RequiredBy` on each dependency seems like a lot of effort though.

Edit:
Thanks to the integration test I realize that showing this dialog for every package that has dependencies isn't very clever..

Ref #980