### PR TITLE
CollectionPage: re-add deb controls and improve layout

### DIFF
--- a/lib/app/collection/collection_model.dart
+++ b/lib/app/collection/collection_model.dart
@@ -33,11 +33,12 @@ class CollectionModel extends SafeChangeNotifier {
       }
     });
     _enabledAppFormats.add(AppFormat.snap);
+    _appFormat = AppFormat.snap;
 
     if (_packageService.isAvailable) {
       _enabledAppFormats.add(AppFormat.packageKit);
-      _appFormat = AppFormat.packageKit;
-      await _packageService.getInstalledPackages(filters: packageKitFilters);
+      await _packageService.getInstalledPackages(filters: _packageKitFilters);
+      _installedPackages = _packageService.installedPackages;
 
       _packagesChanged =
           _packageService.installedPackagesChanged.listen((event) {
@@ -45,8 +46,6 @@ class CollectionModel extends SafeChangeNotifier {
       });
 
       notifyListeners();
-    } else {
-      _appFormat = AppFormat.snap;
     }
 
     await _loadInstalledSnaps();
@@ -80,13 +79,7 @@ class CollectionModel extends SafeChangeNotifier {
   void setAppFormat(AppFormat value) {
     if (value == _appFormat) return;
     _appFormat = value;
-    if (_appFormat == AppFormat.packageKit && _packageService.isAvailable) {
-      _packageService
-          .getInstalledPackages(filters: _packageKitFilters)
-          .then((_) => notifyListeners());
-    } else {
-      notifyListeners();
-    }
+    notifyListeners();
   }
 
   // SNAPS
@@ -202,15 +195,16 @@ class CollectionModel extends SafeChangeNotifier {
 
   // PACKAGEKIT PACKAGES
 
-  List<PackageKitPackageId> get installedPackages {
+  List<PackageKitPackageId>? _installedPackages;
+  List<PackageKitPackageId>? get installedPackages {
     if (!_packageService.isAvailable) {
       return [];
     } else {
       if (searchQuery?.isEmpty ?? true) {
-        return _packageService.installedPackages;
+        return _installedPackages;
       }
-      return _packageService.installedPackages
-          .where((e) => e.name.contains(searchQuery!))
+      return _installedPackages
+          ?.where((e) => e.name.contains(searchQuery!))
           .toList();
     }
   }

--- a/lib/app/collection/package_update_banner.dart
+++ b/lib/app/collection/package_update_banner.dart
@@ -24,8 +24,8 @@ import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-class CollectionPackageUpdateBanner extends StatelessWidget {
-  const CollectionPackageUpdateBanner({
+class PackageUpdateBanner extends StatelessWidget {
+  const PackageUpdateBanner({
     super.key,
     required this.selected,
     this.onChanged,
@@ -42,9 +42,7 @@ class CollectionPackageUpdateBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(10),
-      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6),
       onTap: () => showDialog(
         context: context,
         builder: (_) => UpdateDialog.create(
@@ -84,10 +82,10 @@ class CollectionPackageUpdateBanner extends StatelessWidget {
           group == PackageKitGroup.system || group == PackageKitGroup.security
               ? const _SystemUpdateIcon()
               : const Padding(
-                  padding: EdgeInsets.only(bottom: 5, left: 5),
+                  padding: EdgeInsets.only(bottom: 8, left: 4),
                   child: AppIcon(
                     iconUrl: null,
-                    size: 38,
+                    size: 25,
                   ),
                 ),
       trailing: YaruCheckbox(
@@ -109,11 +107,11 @@ class _SystemUpdateIcon extends StatelessWidget {
     return Stack(
       children: [
         Positioned(
-          bottom: 2,
-          left: 13,
+          bottom: 5,
+          left: 8,
           child: Container(
-            height: 25,
-            width: 25,
+            height: 18,
+            width: 18,
             decoration: const BoxDecoration(
               shape: BoxShape.circle,
               color: Colors.white,
@@ -122,12 +120,12 @@ class _SystemUpdateIcon extends StatelessWidget {
         ),
         const Icon(
           YaruIcons.ubuntu_logo_large,
-          size: 50,
+          size: 35,
           color: YaruColors.orange,
         ),
         Positioned(
           top: -2,
-          right: 2,
+          right: -2,
           child: Icon(
             YaruIcons.shield_filled,
             size: 26,
@@ -135,8 +133,8 @@ class _SystemUpdateIcon extends StatelessWidget {
           ),
         ),
         Positioned(
-          top: 0,
-          right: 2,
+          top: -1,
+          right: -1,
           child: Icon(
             YaruIcons.shield_filled,
             size: 25,


### PR DESCRIPTION
- removed "collection" prefix in files and classes where it does not make sense
- re-add all debian package related controls (refresh, update all)
- adapt the deb updates section to snap updates
- adapt deb updates list to installed deb list
- move PackageUpdatesModel higher in the tree to a multiprovider around collectionpage
- do not always ask packageService for a fresh list of updates on page refresh, stream subs should update the page here
- do not show all debian packages but only     PackageKitFilter.installed,
    PackageKitFilter.gui,
    PackageKitFilter.newest,
    PackageKitFilter.application,
    PackageKitFilter.notSource,
    PackageKitFilter.notDevelopment,

![grafik](https://user-images.githubusercontent.com/15329494/217367605-f57ed28c-b1da-45ce-8e96-b5d38c2c30b0.png)
![grafik](https://user-images.githubusercontent.com/15329494/217367834-6a1cd361-7a0c-49ae-9ec6-1e5bb595ba01.png)

NOTE: this needs a change in yaru widgets to have the button have a padding without having the whole expandable have a padding https://github.com/ubuntu/yaru_widgets.dart/issues/604