### PR TITLE
CollectionModel: remove unecessary list clearing

### DIFF
--- a/lib/app/collection/collection_model.dart
+++ b/lib/app/collection/collection_model.dart
@@ -106,8 +106,6 @@ class CollectionModel extends SafeChangeNotifier {
 
   Future<void> loadSnaps() async {
     checkingForSnapUpdates = true;
-    _installedSnaps = null;
-    snapsWithUpdate.clear();
     await _snapService.loadLocalSnaps();
     await _snapService.loadSnapsWithUpdate();
     _installedSnaps = _snapService.localSnaps;


### PR DESCRIPTION
Was abs. not needed. It's null on start that is correct :+1: 
Afterwards the service takes care