### PR TITLE
PackageService: reduce signals in getInstalledPackages

### DIFF
--- a/lib/services/packagekit/package_service.dart
+++ b/lib/services/packagekit/package_service.dart
@@ -399,7 +399,6 @@ class PackageService {
           event.packageId.name,
           () => event.packageId,
         );
-        setInstalledPackagesChanged(true);
       } else if (event is PackageKitErrorCodeEvent) {
         setErrorMessage('${event.code}: ${event.details}');
       } else if (event is PackageKitFinishedEvent) {
@@ -409,7 +408,9 @@ class PackageService {
     await transaction.getPackages(
       filter: filters,
     );
-    return completer.future.whenComplete(subscription.cancel);
+    await completer.future;
+    await subscription.cancel();
+    setInstalledPackagesChanged(true);
   }
 
   Future<void> _updateGroups(Iterable<PackageKitPackageId> ids) async {


### PR DESCRIPTION
only send one packages changed signal after the transaction completes,
instead of sending one for each packagekit event