### PR TITLE
show all items in Additional Information section

### DIFF
--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -26,47 +26,44 @@ class AdditionalInformation extends StatelessWidget {
         context.l10n.additionalInformation,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      child: ConstrainedBox(
-        constraints: BoxConstraints.loose(const Size(1000, 200)),
-        child: ScrollConfiguration(
-          behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-          child: GridView(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-              maxCrossAxisExtent: 200,
-              mainAxisExtent: 100,
-            ),
-            children: [
-              PublisherInfoFragment(
-                publisherName: appData.publisherName,
-                website: appData.website,
-                verified: appData.verified,
-                starDev: appData.starredDeveloper,
-              ),
-              ReleasedAtInfoFragment(releasedAt: appData.releasedAt),
-              LicenseInfoFragment(
-                headerStyle: headerStyle,
-                license: appData.license,
-              ),
-              // TODO: the category is currently not provided
-              // by snapd, and thus not by snapd.dart
-              // when a snap is found by name
-              // See: https://bugs.launchpad.net/snapd/+bug/1838786/comments/5
-
-              // AppInfoFragment(
-              //   crossAxisAlignment: CrossAxisAlignment.start,
-              //   header: 'Category',
-              //   tooltipMessage: '',
-              //   child: Text(context.l10n.unknown),
-              // ),
-              InstallDateInfoFragment(
-                installDateIsoNorm: appData.installDateIsoNorm,
-                installDate: appData.installDate,
-              ),
-              LinksInfoFragment(appData: appData),
-            ],
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+        child: GridView(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+            maxCrossAxisExtent: 200,
+            mainAxisExtent: 100,
           ),
+          children: [
+            PublisherInfoFragment(
+              publisherName: appData.publisherName,
+              website: appData.website,
+              verified: appData.verified,
+              starDev: appData.starredDeveloper,
+            ),
+            ReleasedAtInfoFragment(releasedAt: appData.releasedAt),
+            LicenseInfoFragment(
+              headerStyle: headerStyle,
+              license: appData.license,
+            ),
+            // TODO: the category is currently not provided
+            // by snapd, and thus not by snapd.dart
+            // when a snap is found by name
+            // See: https://bugs.launchpad.net/snapd/+bug/1838786/comments/5
+
+            // AppInfoFragment(
+            //   crossAxisAlignment: CrossAxisAlignment.start,
+            //   header: 'Category',
+            //   tooltipMessage: '',
+            //   child: Text(context.l10n.unknown),
+            // ),
+            InstallDateInfoFragment(
+              installDateIsoNorm: appData.installDateIsoNorm,
+              installDate: appData.installDate,
+            ),
+            LinksInfoFragment(appData: appData),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Shows all of the items in the additional information section.

After:

https://user-images.githubusercontent.com/73116038/217977554-67cc4b2a-9a72-4cd6-b3e7-173846a4676f.mp4

Fixes #1019 