### PR TITLE
Remove unnecessary toolips

### DIFF
--- a/lib/app/common/app_page/app_infos/app_infos.dart
+++ b/lib/app/common/app_page/app_infos/app_infos.dart
@@ -102,7 +102,6 @@ class RatingInfoFragment extends StatelessWidget {
 
     return AppInfoFragment(
       header: context.l10n.rating,
-      tooltipMessage: averageRating.toString(),
       child: Align(
         alignment: Alignment.center,
         child: Padding(

--- a/lib/app/common/app_page/app_infos/app_size_fragment.dart
+++ b/lib/app/common/app_page/app_infos/app_size_fragment.dart
@@ -11,7 +11,6 @@ class AppSizeFragment extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppInfoFragment(
       header: context.l10n.size,
-      tooltipMessage: appSize,
       child: Text(
         appSize,
         textAlign: TextAlign.center,

--- a/lib/app/common/app_page/app_infos/confinment_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/confinment_info_fragment.dart
@@ -17,7 +17,6 @@ class ConfinementInfoFragment extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppInfoFragment(
       header: context.l10n.confinement,
-      tooltipMessage: confinementName,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/app/common/app_page/app_infos/install_date_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/install_date_info_fragment.dart
@@ -17,7 +17,6 @@ class InstallDateInfoFragment extends StatelessWidget {
     return AppInfoFragment(
       crossAxisAlignment: CrossAxisAlignment.start,
       header: context.l10n.installDate,
-      tooltipMessage: installDateIsoNorm,
       child: Text(
         installDate.isNotEmpty ? installDate : context.l10n.notInstalled,
         maxLines: 1,

--- a/lib/app/common/app_page/app_infos/license_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/license_info_fragment.dart
@@ -17,7 +17,6 @@ class LicenseInfoFragment extends StatelessWidget {
     return AppInfoFragment(
       crossAxisAlignment: CrossAxisAlignment.start,
       header: context.l10n.license,
-      tooltipMessage: license,
       child: Text(
         license,
         overflow: TextOverflow.ellipsis,

--- a/lib/app/common/app_page/app_infos/license_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/license_info_fragment.dart
@@ -17,6 +17,7 @@ class LicenseInfoFragment extends StatelessWidget {
     return AppInfoFragment(
       crossAxisAlignment: CrossAxisAlignment.start,
       header: context.l10n.license,
+      tooltipMessage: license.length > 20 ? license : null,
       child: Text(
         license,
         overflow: TextOverflow.ellipsis,

--- a/lib/app/common/app_page/app_infos/publisher_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/publisher_info_fragment.dart
@@ -91,7 +91,7 @@ class PublisherInfoFragment extends StatelessWidget {
     return AppInfoFragment(
       crossAxisAlignment: CrossAxisAlignment.start,
       header: context.l10n.publisher,
-      tooltipMessage: publisherName,
+      tooltipMessage: publisherName.length > 12 ? publisherName : null,
       child: box,
     );
   }

--- a/lib/app/common/app_page/app_infos/released_at_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/released_at_info_fragment.dart
@@ -12,7 +12,6 @@ class ReleasedAtInfoFragment extends StatelessWidget {
     return AppInfoFragment(
       crossAxisAlignment: CrossAxisAlignment.start,
       header: context.l10n.releasedAt,
-      tooltipMessage: releasedAt,
       child: Text(
         releasedAt,
         textAlign: TextAlign.center,

--- a/lib/app/common/app_page/app_infos/version_info_fragment.dart
+++ b/lib/app/common/app_page/app_infos/version_info_fragment.dart
@@ -17,7 +17,7 @@ class VersionInfoFragment extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppInfoFragment(
       header: context.l10n.version,
-      tooltipMessage: version,
+      tooltipMessage: version.length > 12 ? version : null,
       child: Text(
         version,
         overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
@Feichtmeier @local-optimum @Jupi007 continuing to explore a solution to  [#887](https://github.com/ubuntu-flutter-community/software/issues/887) on how to avoid redundant information, could this solution work?

- removed unnecessary tooltips
- added a length threshold for Version and Publisher


