### PR TITLE
Package type visualization improvements

### DIFF
--- a/lib/app/common/app_page/app_format_toggle_buttons.dart
+++ b/lib/app/common/app_page/app_format_toggle_buttons.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:software/app/common/app_format.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
@@ -20,71 +21,57 @@ class AppFormatToggleButtons extends StatelessWidget {
         isSelected: isSelected,
         onPressed: onPressed,
         children: const [
-          SnapLabel(),
-          DebianLabel(),
+          AppFormatLabel(appFormat: AppFormat.snap),
+          AppFormatLabel(appFormat: AppFormat.packageKit)
         ],
       ),
     );
   }
 }
 
-class SnapLabel extends StatelessWidget {
-  const SnapLabel({
+class AppFormatLabel extends StatelessWidget {
+  const AppFormatLabel({
     super.key,
+    required this.appFormat,
   });
+
+  final AppFormat appFormat;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         const SizedBox(
           width: 10,
         ),
-        Icon(
-          YaruIcons.snapcraft,
-          color: theme.colorScheme.onSurface,
-          size: 16,
-        ),
+        if (appFormat == AppFormat.snap)
+          Icon(
+            YaruIcons.snapcraft,
+            color: theme.colorScheme.onSurface,
+            size: 16,
+          )
+        else
+          Icon(
+            YaruIcons.debian,
+            color: theme.colorScheme.onSurface,
+            size: 16,
+          ),
         const SizedBox(
           width: 5,
         ),
-        Text(context.l10n.snapPackage),
+        if (appFormat == AppFormat.snap)
+          Text(context.l10n.snapPackage)
+        else
+          Text(context.l10n.debianPackage),
         const SizedBox(
           width: 10,
         ),
-      ],
-    );
-  }
-}
-
-class DebianLabel extends StatelessWidget {
-  const DebianLabel({
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
         const SizedBox(
           width: 10,
-        ),
-        Icon(
-          YaruIcons.debian,
-          color: theme.colorScheme.onSurface,
-          size: 16,
-        ),
-        const SizedBox(
-          width: 5,
-        ),
-        Text(context.l10n.debianPackage),
-        const SizedBox(
-          width: 10,
-        ),
+        )
       ],
     );
   }

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -173,10 +173,16 @@ class _PackagePageState extends State<PackagePage> {
     );
 
     final preControls = widget.snap == null
-        ? const BorderContainer(
-            padding: EdgeInsets.symmetric(horizontal: 5),
+        ? BorderContainer(
+            color: theme.dividerColor,
+            padding: const EdgeInsets.symmetric(horizontal: 5),
             borderRadius: 6,
-            child: SizedBox(height: 40, child: DebianLabel()),
+            child: const SizedBox(
+              height: 40,
+              child: AppFormatLabel(
+                appFormat: AppFormat.packageKit,
+              ),
+            ),
           )
         : AppFormatToggleButtons(
             isSelected: const [

--- a/lib/app/common/snap/snap_controls.dart
+++ b/lib/app/common/snap/snap_controls.dart
@@ -64,7 +64,8 @@ class SnapControls extends StatelessWidget {
             ]
           : [
               if (model.selectableChannels.isNotEmpty &&
-                  model.selectableChannels.length > 1)
+                  model.selectableChannels.length > 1 &&
+                  appstream != null)
                 const SnapChannelPopupButton(),
               if (model.snapIsInstalled)
                 OutlinedButton(

--- a/lib/app/common/snap/snap_page.dart
+++ b/lib/app/common/snap/snap_page.dart
@@ -26,10 +26,10 @@ import 'package:software/app/common/app_icon.dart';
 import 'package:software/app/common/app_page/app_format_toggle_buttons.dart';
 import 'package:software/app/common/app_page/app_page.dart';
 import 'package:software/app/common/app_rating.dart';
-import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/packagekit/package_page.dart';
 import 'package:software/app/common/rating_model.dart';
 import 'package:software/app/common/review_model.dart';
+import 'package:software/app/common/snap/snap_channel_button.dart';
 import 'package:software/app/common/snap/snap_connections_button.dart';
 import 'package:software/app/common/snap/snap_connections_dialog.dart';
 import 'package:software/app/common/snap/snap_controls.dart';
@@ -38,6 +38,7 @@ import 'package:software/l10n/l10n.dart';
 import 'package:software/services/odrs_service.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class SnapPage extends StatefulWidget {
   const SnapPage({super.key, this.appstream, required this.snap});
@@ -119,6 +120,7 @@ class _SnapPageState extends State<SnapPage> {
     final model = context.watch<SnapModel>();
     final rating = context.select((RatingModel m) => m.getRating(_ratingId));
     final userReviews = context.select((ReviewModel m) => m.userReviews);
+    final theme = Theme.of(context);
 
     final appData = AppData(
       releasedAt: model.selectedChannelReleasedAt,
@@ -152,6 +154,43 @@ class _SnapPageState extends State<SnapPage> {
       appstream: widget.appstream,
     );
 
+    const snapLabel = SizedBox(
+      height: 39,
+      child: AppFormatLabel(appFormat: AppFormat.snap),
+    );
+
+    final snapLabelContainerCut = YaruBorderContainer(
+      color: theme.dividerColor,
+      padding: const EdgeInsets.symmetric(horizontal: 5),
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(kYaruButtonRadius),
+        bottomLeft: Radius.circular(kYaruButtonRadius),
+      ),
+      child: snapLabel,
+    );
+
+    final snapLabelWithChannelButton = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        snapLabelContainerCut,
+        OutlinedButtonTheme(
+          data: OutlinedButtonThemeData(
+            style: OutlinedButtonTheme.of(context).style?.copyWith(
+                  shape: MaterialStateProperty.resolveWith(
+                    (states) => const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.only(
+                        topRight: Radius.circular(kYaruButtonRadius),
+                        bottomRight: Radius.circular(kYaruButtonRadius),
+                      ),
+                    ),
+                  ),
+                ),
+          ),
+          child: const SnapChannelPopupButton(),
+        )
+      ],
+    );
+
     final preControls = Wrap(
       spacing: 10,
       children: [
@@ -173,11 +212,7 @@ class _SnapPageState extends State<SnapPage> {
             },
           )
         else
-          const BorderContainer(
-            padding: EdgeInsets.symmetric(horizontal: 5),
-            borderRadius: 6,
-            child: SizedBox(height: 39, child: SnapLabel()),
-          ),
+          snapLabelWithChannelButton,
         if (model.snapIsInstalled && model.strict)
           SnapConnectionsButton(
             onPressed: () => showDialog(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   yaru: ^0.5.1
   yaru_colors: ^0.1.3
   yaru_icons: ^1.0.3
-  yaru_widgets: ^2.0.2
+  yaru_widgets: ^2.0.3
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
Snap and Deb available:
![grafik](https://user-images.githubusercontent.com/15329494/218441829-781f5319-6b9a-4dc5-85b1-a2f28b336ba3.png)
![grafik](https://user-images.githubusercontent.com/15329494/218441863-014ceba0-779b-4d03-ab41-bab4f23a1f59.png)

Only snap but with multiple channels:
![grafik](https://user-images.githubusercontent.com/15329494/218442021-b4e982ef-6401-4ace-9621-fd7b14e40728.png)

Only 1 channel and only snap:
![grafik](https://user-images.githubusercontent.com/15329494/218442519-f502b71c-ea92-445c-bae7-db0d6fe2047e.png)


Fixes #1036