### PR TITLE
Added padding to snapchannel popup button

### DIFF
--- a/lib/app/common/snap/snap_channel_button.dart
+++ b/lib/app/common/snap/snap_channel_button.dart
@@ -37,6 +37,7 @@ class SnapChannelPopupButton extends StatelessWidget {
     final light = theme.brightness == Brightness.light;
 
     return YaruPopupMenuButton(
+      padding: const EdgeInsets.only(left: 15, right: 5),
       initialValue: model.channelToBeInstalled,
       tooltip: context.l10n.channel,
       itemBuilder: (v) => [


### PR DESCRIPTION
When I tried https://github.com/ubuntu-flutter-community/software/pull/1040 I noticed missing padding in the dropdown

Before:
![image](https://user-images.githubusercontent.com/3986894/218592568-8ddf92ab-28c5-42e6-ae4c-49c2a710594c.png)

This PR:
![image](https://user-images.githubusercontent.com/3986894/218592812-5d8a23b5-7015-4596-9acd-8037561a7746.png)
![image](https://user-images.githubusercontent.com/3986894/218592930-45710afe-af41-4d83-99f9-c191c6c14626.png)

