### PR TITLE
Correctly look for snap updates

### DIFF
--- a/lib/app/common/snap/snap_controls.dart
+++ b/lib/app/common/snap/snap_controls.dart
@@ -74,10 +74,10 @@ class SnapControls extends StatelessWidget {
                 ),
               if (model.snapIsInstalled)
                 ElevatedButton(
-                  onPressed: (model.selectedChannelVersion != model.version) &&
-                          !model.snapChangeInProgress
-                      ? model.refresh
-                      : null,
+                  onPressed:
+                      model.isUpdateAvailable() && !model.snapChangeInProgress
+                          ? model.refresh
+                          : null,
                   child: Text(
                     context.l10n.updateButton,
                   ),

--- a/lib/app/common/snap/snap_model.dart
+++ b/lib/app/common/snap/snap_model.dart
@@ -22,6 +22,7 @@ import 'package:data_size/data_size.dart';
 import 'package:intl/intl.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:snapd/snapd.dart';
+import 'package:software/app/common/snap/snap_utils.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:software/snapx.dart';
 
@@ -400,5 +401,11 @@ class SnapModel extends SafeChangeNotifier {
       return selectableChannels.entries.first.key;
     }
     return '';
+  }
+
+  bool isUpdateAvailable() {
+    return _storeSnap == null || _localSnap == null
+        ? false
+        : isSnapUpdateAvailable(storeSnap: _storeSnap!, localSnap: _localSnap!);
   }
 }

--- a/lib/app/common/snap/snap_page.dart
+++ b/lib/app/common/snap/snap_page.dart
@@ -141,9 +141,7 @@ class _SnapPageState extends State<SnapPage> {
           model.version,
       screenShotUrls: model.screenshotUrls ?? [],
       description: model.description ?? '',
-      versionChanged:
-          model.selectableChannels[model.channelToBeInstalled]?.version !=
-              model.version,
+      versionChanged: model.isUpdateAvailable(),
       userReviews: userReviews ?? [],
       averageRating: rating?.average ?? 0.0,
       appFormat: AppFormat.snap,

--- a/lib/app/common/snap/snap_utils.dart
+++ b/lib/app/common/snap/snap_utils.dart
@@ -12,7 +12,7 @@ bool isSnapUpdateAvailable({required Snap storeSnap, required Snap localSnap}) {
   );
   final trackingVersion = selectAbleChannels[tracking]?.version;
 
-  return trackingVersion != version;
+  return trackingVersion == null ? false : trackingVersion != version;
 }
 
 Map<String, SnapChannel> getSelectableChannels({required Snap? storeSnap}) {


### PR DESCRIPTION
It turns out that the issue was something totally different. I didn't check if the selected channel version is null.
Which I did now and then there is no version to compare to which means that there is no update available.
I first ran `snap refresh kde...." in the terminal and snapd said that there is no update available. After that I found the bug in the code

![grafik](https://user-images.githubusercontent.com/15329494/218732570-668b733f-edb2-45df-b43b-65918b18b26a.png)


Fixes #1042