### PR TITLE
Revert "exempt common bots from CLA (#1053)"

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -3,9 +3,8 @@ on: [pull_request_target]
 
 jobs:
   cla-check:
+    if: github.event.pull_request.user.login != 'weblate'
     runs-on: ubuntu-20.04
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1
-        with:
-          exempted-bots: dependabot,renovate,weblate


### PR DESCRIPTION
This reverts commit fe060388bc8bced4d9432cabb4f65d595ca4021c.

Sorry, this doesn't work - the username weblate uses does not end in '[bot]'.
See https://github.com/canonical/has-signed-canonical-cla/blob/main/index.js#L63