### PR TITLE
Use snapd.dart to find snaps with updates

### DIFF
--- a/lib/app/collection/collection_model.dart
+++ b/lib/app/collection/collection_model.dart
@@ -97,7 +97,7 @@ class CollectionModel extends SafeChangeNotifier {
     checkingForSnapUpdates = true;
     await _snapService.loadLocalSnaps();
     await _snapService.loadSnapsWithUpdate();
-    _installedSnaps = _snapService.localSnaps;
+    _installedSnaps = _snapService.localSnaps.toList();
     for (var update in snapsWithUpdate) {
       for (var snap in _installedSnaps!) {
         if (update.name == snap.name) {

--- a/lib/app/common/snap/snap_model.dart
+++ b/lib/app/common/snap/snap_model.dart
@@ -22,7 +22,6 @@ import 'package:data_size/data_size.dart';
 import 'package:intl/intl.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:snapd/snapd.dart';
-import 'package:software/app/common/snap/snap_utils.dart';
 import 'package:software/services/snap_service.dart';
 import 'package:software/snapx.dart';
 
@@ -39,6 +38,7 @@ class SnapModel extends SafeChangeNotifier {
     await _snapService.authorize();
     await _loadSnapChangeInProgress();
     await _loadChange();
+    await _snapService.loadSnapsWithUpdate();
 
     _localSnap = await _findLocalSnap(huskSnapName);
     if (online) {
@@ -403,9 +403,8 @@ class SnapModel extends SafeChangeNotifier {
     return '';
   }
 
-  bool isUpdateAvailable() {
-    return _storeSnap == null || _localSnap == null
-        ? false
-        : isSnapUpdateAvailable(storeSnap: _storeSnap!, localSnap: _localSnap!);
-  }
+  bool isUpdateAvailable() =>
+      _snapService.snapsWithUpdate
+          .indexWhere((snap) => snap.name == huskSnapName) >=
+      0;
 }

--- a/lib/app/common/snap/snap_utils.dart
+++ b/lib/app/common/snap/snap_utils.dart
@@ -1,20 +1,6 @@
 import 'package:snapd/snapd.dart';
 import 'package:software/app/common/snap/snap_sort.dart';
 
-bool isSnapUpdateAvailable({required Snap storeSnap, required Snap localSnap}) {
-  if (storeSnap.name == 'snapcraft') return false;
-  final version = localSnap.version;
-
-  final selectAbleChannels = getSelectableChannels(storeSnap: storeSnap);
-  final tracking = getTrackingChannel(
-    trackingChannel: localSnap.trackingChannel,
-    selectableChannels: selectAbleChannels,
-  );
-  final trackingVersion = selectAbleChannels[tracking]?.version;
-
-  return trackingVersion == null ? false : trackingVersion != version;
-}
-
 Map<String, SnapChannel> getSelectableChannels({required Snap? storeSnap}) {
   Map<String, SnapChannel> selectableChannels = {};
   if (storeSnap != null && storeSnap.tracks.isNotEmpty) {

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -306,31 +306,11 @@ class SnapService {
     _sectionsChangedController.add(section);
   }
 
-  final List<Snap> _snapsWithUpdate = [];
-  List<Snap> get snapsWithUpdate => _snapsWithUpdate;
-  Future<List<Snap>> loadSnapsWithUpdate() async {
-    List<Snap> localSnaps = await _snapDClient.getSnaps();
-
-    Map<Snap, Snap> localSnapsToStoreSnaps = {};
-    for (var snap in localSnaps) {
-      final storeSnap = await findSnapByName(snap.name) ?? snap;
-      localSnapsToStoreSnaps.putIfAbsent(snap, () => storeSnap);
-    }
-
-    final snapsWithUpdates = localSnaps.where((snap) {
-      if (localSnapsToStoreSnaps[snap] == null) return false;
-      return isSnapUpdateAvailable(
-        storeSnap: localSnapsToStoreSnaps[snap]!,
-        localSnap: snap,
-      );
-    }).toList();
-
-    if (_snapsWithUpdate.length != snapsWithUpdates.length) {
-      _snapsWithUpdate.clear();
-      _snapsWithUpdate.addAll(snapsWithUpdates);
-    }
-
-    return _snapsWithUpdate;
+  List<Snap> _snapsWithUpdate = [];
+  UnmodifiableListView<Snap> get snapsWithUpdate =>
+      UnmodifiableListView(_snapsWithUpdate);
+  Future<void> loadSnapsWithUpdate() async {
+    _snapsWithUpdate = await _snapDClient.find(select: 'refresh');
   }
 
   Future<void> refreshAll({

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -21,7 +21,6 @@ import 'package:collection/collection.dart';
 import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/common/snap/snap_section.dart';
-import 'package:software/app/common/snap/snap_utils.dart';
 import 'package:software/snapd_change_x.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -121,15 +121,11 @@ class SnapService {
     }
   }
 
-  final List<Snap> _localSnaps = [];
-  List<Snap> get localSnaps => _localSnaps;
-  Future<List<Snap>> loadLocalSnaps() async {
-    final snaps = (await _snapDClient.getSnaps());
-    if (snaps.length != _localSnaps.length) {
-      _localSnaps.clear();
-      _localSnaps.addAll(snaps);
-    }
-    return _localSnaps;
+  List<Snap> _localSnaps = [];
+  UnmodifiableListView<Snap> get localSnaps =>
+      UnmodifiableListView(_localSnaps);
+  Future<void> loadLocalSnaps() async {
+    _localSnaps = (await _snapDClient.getSnaps());
   }
 
   Future<List<Snap>> findSnapsByQuery({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,10 @@ dependencies:
   quiver: ^3.1.0
   safe_change_notifier: ^0.2.0
   shimmer: ^2.0.0
-  snapd: ^0.4.6
+  snapd:
+    git:
+      url: https://github.com/d-loose/snapd.dart
+      ref: find-select
   snowball_stemmer: ^0.1.0
   synchronized: ^3.0.0+3
   ubuntu_service: ^0.2.0

--- a/test/services/snap_service_test.dart
+++ b/test/services/snap_service_test.dart
@@ -472,15 +472,9 @@ void main() {
     when(mockSnapdClient.getSnaps).thenAnswer(
       (_) async => [snapWithUpdateOld, snapWithoutUpdate],
     );
-    when(() => mockSnapdClient.find(section: any(named: 'name'))).thenAnswer(
-      (i) async =>
-          i.namedArguments[const Symbol('name')] == snapWithUpdateOld.name
-              ? [snapWithUpdateNew]
-              : i.namedArguments[const Symbol('name')] == snapWithoutUpdate.name
-                  ? [snapWithoutUpdate]
-                  : [],
-    );
+    when(() => mockSnapdClient.find(select: 'refresh'))
+        .thenAnswer((_) async => [snapWithUpdateNew]);
     await service.loadSnapsWithUpdate();
-    expect(service.snapsWithUpdate, [snapWithUpdateOld]);
+    expect(service.snapsWithUpdate, [snapWithUpdateNew]);
   });
 }


### PR DESCRIPTION
Removes some client side logic that is no longer needed.

Fixes #1062