### PR TITLE
Remove `pubspec_overrides.yaml`

### DIFF
--- a/pubspec_overrides.yaml
+++ b/pubspec_overrides.yaml
@@ -1,9 +1,0 @@
-dependency_overrides:
-  handy_window:
-    git:
-      ref: main
-      url: https://github.com/ubuntu-flutter-community/handy_window
-  window_manager:
-    git:
-      ref: linux-hide-title
-      url: https://github.com/jpnurmi/window_manager


### PR DESCRIPTION
No longer needed with `yaru_window`.