### PR TITLE
Smaller fontsize for YaruExpanders

### DIFF
--- a/lib/app/collection/package_updates_page.dart
+++ b/lib/app/collection/package_updates_page.dart
@@ -25,6 +25,7 @@ import 'package:software/app/common/message_bar.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/packagekit/updates_state.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import '../common/expandable_title.dart';
 
 class PackageUpdatesPage extends StatefulWidget {
   const PackageUpdatesPage({
@@ -234,10 +235,9 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
                   width: 10,
                 ),
                 Expanded(
-                  child: Text(
-                    '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
-                    style: Theme.of(context).textTheme.titleLarge,
-                    overflow: TextOverflow.ellipsis,
+                  child: YaruExpandableTitle(
+                    title:
+                        '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
                   ),
                 )
               ],

--- a/lib/app/collection/package_updates_page.dart
+++ b/lib/app/collection/package_updates_page.dart
@@ -236,8 +236,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
                 ),
                 Expanded(
                   child: YaruExpandableTitle(
-                    title:
-                        '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
+                    '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
                   ),
                 )
               ],

--- a/lib/app/collection/package_updates_page.dart
+++ b/lib/app/collection/package_updates_page.dart
@@ -235,7 +235,7 @@ class _UpdatesListViewState extends State<_UpdatesListView> {
                   width: 10,
                 ),
                 Expanded(
-                  child: YaruExpandableTitle(
+                  child: ExpandableContainerTitle(
                     '${model.selectedUpdatesLength}/${model.updates.length} ${context.l10n.xSelected}',
                   ),
                 )

--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -21,6 +21,7 @@ import 'package:software/l10n/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import '../expandable_title.dart';
 
 class AppDescription extends StatelessWidget {
   const AppDescription({super.key, required this.description});
@@ -32,9 +33,8 @@ class AppDescription extends StatelessWidget {
     return YaruExpandable(
       isExpanded: true,
       expandIcon: const Icon(YaruIcons.pan_end),
-      header: Text(
-        context.l10n.description,
-        style: Theme.of(context).textTheme.titleLarge,
+      header: YaruExpandableTitle(
+        title: context.l10n.description,
       ),
       child: Padding(
         padding: const EdgeInsets.only(top: 20),

--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -33,7 +33,7 @@ class AppDescription extends StatelessWidget {
     return YaruExpandable(
       isExpanded: true,
       expandIcon: const Icon(YaruIcons.pan_end),
-      header: YaruExpandableTitle(
+      header: ExpandableContainerTitle(
         context.l10n.description,
       ),
       child: Padding(

--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -34,7 +34,7 @@ class AppDescription extends StatelessWidget {
       isExpanded: true,
       expandIcon: const Icon(YaruIcons.pan_end),
       header: YaruExpandableTitle(
-        title: context.l10n.description,
+        context.l10n.description,
       ),
       child: Padding(
         padding: const EdgeInsets.only(top: 20),

--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -7,6 +7,7 @@ import 'package:software/app/common/app_page/app_infos/publisher_info_fragment.d
 import 'package:software/app/common/app_page/app_infos/released_at_info_fragment.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import '../../expandable_title.dart';
 
 const headerStyle = TextStyle(fontWeight: FontWeight.w500, fontSize: 14);
 
@@ -22,9 +23,8 @@ class AdditionalInformation extends StatelessWidget {
   Widget build(BuildContext context) {
     return YaruExpandable(
       isExpanded: true,
-      header: Text(
-        context.l10n.additionalInformation,
-        style: Theme.of(context).textTheme.titleLarge,
+      header: YaruExpandableTitle(
+        title: context.l10n.additionalInformation,
       ),
       child: ScrollConfiguration(
         behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),

--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -23,7 +23,7 @@ class AdditionalInformation extends StatelessWidget {
   Widget build(BuildContext context) {
     return YaruExpandable(
       isExpanded: true,
-      header: YaruExpandableTitle(
+      header: ExpandableContainerTitle(
         context.l10n.additionalInformation,
       ),
       child: ScrollConfiguration(

--- a/lib/app/common/app_page/app_infos/additional_information.dart
+++ b/lib/app/common/app_page/app_infos/additional_information.dart
@@ -24,7 +24,7 @@ class AdditionalInformation extends StatelessWidget {
     return YaruExpandable(
       isExpanded: true,
       header: YaruExpandableTitle(
-        title: context.l10n.additionalInformation,
+        context.l10n.additionalInformation,
       ),
       child: ScrollConfiguration(
         behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -120,7 +120,7 @@ class _AppPageState extends State<AppPage> {
       child: YaruExpandable(
         isExpanded: true,
         header: YaruExpandableTitle(
-          title: context.l10n.gallery,
+          context.l10n.gallery,
         ),
         child: YaruCarousel(
           controller: controller,

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -35,6 +35,7 @@ import 'package:software/app/explore/explore_model.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import '../expandable_title.dart';
 
 class AppPage extends StatefulWidget {
   const AppPage({
@@ -118,9 +119,8 @@ class _AppPageState extends State<AppPage> {
       initialized: widget.initialized,
       child: YaruExpandable(
         isExpanded: true,
-        header: Text(
-          context.l10n.gallery,
-          style: Theme.of(context).textTheme.titleLarge,
+        header: YaruExpandableTitle(
+          title: context.l10n.gallery,
         ),
         child: YaruCarousel(
           controller: controller,

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -119,7 +119,7 @@ class _AppPageState extends State<AppPage> {
       initialized: widget.initialized,
       child: YaruExpandable(
         isExpanded: true,
-        header: YaruExpandableTitle(
+        header: ExpandableContainerTitle(
           context.l10n.gallery,
         ),
         child: YaruCarousel(

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -73,7 +73,7 @@ class _AppReviewsState extends State<AppReviews> {
       initialized: widget.initialized,
       child: YaruExpandable(
         isExpanded: false,
-        header: YaruExpandableTitle(
+        header: ExpandableContainerTitle(
           context.l10n.reviewsAndRatings,
         ),
         child: Column(

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -9,6 +9,7 @@ import 'package:software/app/common/border_container.dart';
 import 'package:software/app/common/constants.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import '../expandable_title.dart';
 
 class AppReviews extends StatefulWidget {
   const AppReviews({
@@ -72,10 +73,8 @@ class _AppReviewsState extends State<AppReviews> {
       initialized: widget.initialized,
       child: YaruExpandable(
         isExpanded: false,
-        header: Text(
-          context.l10n.reviewsAndRatings,
-          style: Theme.of(context).textTheme.titleLarge,
-          overflow: TextOverflow.ellipsis,
+        header: YaruExpandableTitle(
+          title: context.l10n.reviewsAndRatings,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -74,7 +74,7 @@ class _AppReviewsState extends State<AppReviews> {
       child: YaruExpandable(
         isExpanded: false,
         header: YaruExpandableTitle(
-          title: context.l10n.reviewsAndRatings,
+          context.l10n.reviewsAndRatings,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/app/common/expandable_title.dart
+++ b/lib/app/common/expandable_title.dart
@@ -3,7 +3,12 @@ import 'package:flutter/material.dart';
 class YaruExpandableTitle extends StatelessWidget {
   final String title;
 
-  const YaruExpandableTitle(this.title);
+  final Key? titleKey;
+
+  const YaruExpandableTitle(
+    this.title, {
+    this.titleKey,
+  }) : super(key: titleKey);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/common/expandable_title.dart
+++ b/lib/app/common/expandable_title.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class YaruExpandableTitle extends StatelessWidget {
+  final String title;
+
+  const YaruExpandableTitle({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17),
+      overflow: TextOverflow.ellipsis,
+      maxLines: 1,
+    );
+  }
+}

--- a/lib/app/common/expandable_title.dart
+++ b/lib/app/common/expandable_title.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
-class YaruExpandableTitle extends StatelessWidget {
+class ExpandableContainerTitle extends StatelessWidget {
   final String title;
 
-  const YaruExpandableTitle(this.title, {super.key});
+  const ExpandableContainerTitle(this.title, {super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/common/expandable_title.dart
+++ b/lib/app/common/expandable_title.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class YaruExpandableTitle extends StatelessWidget {
   final String title;
 
-  const YaruExpandableTitle({required this.title});
+  const YaruExpandableTitle(this.title);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/common/expandable_title.dart
+++ b/lib/app/common/expandable_title.dart
@@ -3,12 +3,7 @@ import 'package:flutter/material.dart';
 class YaruExpandableTitle extends StatelessWidget {
   final String title;
 
-  final Key? titleKey;
-
-  const YaruExpandableTitle(
-    this.title, {
-    this.titleKey,
-  }) : super(key: titleKey);
+  const YaruExpandableTitle(this.title, {super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -226,8 +226,7 @@ class _PackagePageState extends State<PackagePage> {
       initialized: initialized,
       child: YaruExpandable(
         header: YaruExpandableTitle(
-          title:
-              '${context.l10n.dependencies} (${model.missingDependencies.length})',
+          '${context.l10n.dependencies} (${model.missingDependencies.length})',
         ),
         child: Padding(
           padding: const EdgeInsets.only(top: 10),

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -41,6 +41,7 @@ import 'package:software/services/packagekit/package_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+import '../expandable_title.dart';
 
 class PackagePage extends StatefulWidget {
   const PackagePage({
@@ -224,9 +225,9 @@ class _PackagePageState extends State<PackagePage> {
     final dependencies = BorderContainer(
       initialized: initialized,
       child: YaruExpandable(
-        header: Text(
-          '${context.l10n.dependencies} (${model.missingDependencies.length})',
-          style: Theme.of(context).textTheme.titleLarge,
+        header: YaruExpandableTitle(
+          title:
+              '${context.l10n.dependencies} (${model.missingDependencies.length})',
         ),
         child: Padding(
           padding: const EdgeInsets.only(top: 10),

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -225,7 +225,7 @@ class _PackagePageState extends State<PackagePage> {
     final dependencies = BorderContainer(
       initialized: initialized,
       child: YaruExpandable(
-        header: YaruExpandableTitle(
+        header: ExpandableContainerTitle(
           '${context.l10n.dependencies} (${model.missingDependencies.length})',
         ),
         child: Padding(


### PR DESCRIPTION
@anasereijo mentioned making the expander titles a bit smaller. It quickly became a mess, so @Jupi007 suggested creating a YaruExpandableTitle widget. 

Current master:
![image](https://user-images.githubusercontent.com/3986894/219804254-da6d76f9-ab0f-49fb-af08-795fb94f95fe.png)

PR:
![image](https://user-images.githubusercontent.com/3986894/219804139-dd593bad-2faf-4bd2-a8f1-a957c0e165e9.png)

Updates:
<img width="540px" src="https://user-images.githubusercontent.com/3986894/219805231-9f9a41a9-ebc9-4a38-8e76-fb557af7d6fa.gif">
