### PR TITLE
Fixed apppage title size

### DIFF
--- a/lib/app/common/app_page/app_header.dart
+++ b/lib/app/common/app_page/app_header.dart
@@ -71,7 +71,7 @@ class BannerAppHeader extends StatelessWidget {
                   children: [
                     Text(
                       appData.title,
-                      style: theme.textTheme.titleLarge,
+                      style: theme.textTheme.titleLarge!.copyWith(fontSize: 23),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -131,7 +131,6 @@ class PageAppHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scaledFontSize = (800 / appData.title.length.toDouble());
     final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -156,11 +155,9 @@ class PageAppHeader extends StatelessWidget {
                 children: [
                   Text(
                     appData.title,
-                    style: theme.textTheme.displaySmall!.copyWith(
-                      fontSize: scaledFontSize > 44 ? 44 : scaledFontSize,
-                      color: theme.colorScheme.onSurface,
+                    style: theme.textTheme.titleLarge!.copyWith(
+                      fontSize: 23,
                     ),
-                    overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,
                   ),
                   Center(


### PR DESCRIPTION
Removed _scaledFontSize_ and set _titleLarge_ at size 23. In the issue screenshots I used font-size 24, but had an overflow issue with special characters.

Fixes #1088 

I've removed the eclipses for the layout where there's plenty of space. 

### Before:
<img  src="https://user-images.githubusercontent.com/3986894/219858988-f470ed03-d26b-4eb9-8f28-104f4924dd4c.png">

### After:
<img  src="https://user-images.githubusercontent.com/3986894/219858703-44984034-e59b-46d5-8b69-958aebb6572c.png">





