### PR TITLE
Snap channel dropdown text styling

### DIFF
--- a/lib/app/common/snap/snap_channel_button.dart
+++ b/lib/app/common/snap/snap_channel_button.dart
@@ -84,18 +84,18 @@ class _Item extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final labelStyle = TextStyle(
-      color: theme.disabledColor,
-      fontSize: 14,
+      fontWeight: FontWeight.normal,
+      color: theme.hintColor,
     );
     const infoStyle = TextStyle(
       overflow: TextOverflow.ellipsis,
-      fontSize: 14,
+      fontWeight: FontWeight.normal,
     );
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Padding(
-          padding: const EdgeInsets.all(8.0),
+          padding: const EdgeInsets.all(10.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [


### PR DESCRIPTION
Some cleanup 🧹 IMHO much easier to read.

- slightly darker grey using the hint color.
- the font size was already 14
- normal font weight is easier to read

![image](https://user-images.githubusercontent.com/3986894/219903245-ec455964-379b-48a3-b95e-fbe52ce32f95.png)


![image](https://user-images.githubusercontent.com/3986894/219903250-8cdc2c1f-ca62-4da5-936a-8acd9871e7d3.png)
