### PR TITLE
Use primary color for links

### DIFF
--- a/lib/app/collection/package_update_dialog.dart
+++ b/lib/app/collection/package_update_dialog.dart
@@ -108,6 +108,10 @@ class _PackageUpdateDialogState extends State<PackageUpdateDialog> {
               selectable: true,
               onTapLink: (text, href, title) =>
                   href != null ? launchUrl(Uri.parse(href)) : null,
+              styleSheet: MarkdownStyleSheet(
+                p: Theme.of(context).textTheme.bodyMedium,
+                a: TextStyle(color: Theme.of(context).primaryColor),
+              ),
             ),
           ),
         ),

--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -46,6 +46,7 @@ class AppDescription extends StatelessWidget {
               href != null ? launchUrl(Uri.parse(href)) : null,
           styleSheet: MarkdownStyleSheet(
             p: Theme.of(context).textTheme.bodyMedium,
+            a: TextStyle(color: Theme.of(context).primaryColor),
           ),
         ),
       ),

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -375,6 +375,10 @@ class _AboutDialog extends StatelessWidget {
                         data: '${context.l10n.madeBy}:\n ${snapshot.data!}',
                         onTapLink: (text, href, title) =>
                             href != null ? launchUrl(Uri.parse(href)) : null,
+                        styleSheet: MarkdownStyleSheet(
+                          p: Theme.of(context).textTheme.bodyMedium,
+                          a: TextStyle(color: Theme.of(context).primaryColor),
+                        ),
                       );
                     } else {
                       return const SizedBox();


### PR DESCRIPTION
Use primary color for links in apppage _description_ and update _changelog_

Before / After:

![image](https://user-images.githubusercontent.com/3986894/219904299-c6333520-3522-4562-8c55-1001aa09de13.png)
