### PR TITLE
Dependency expander text color

### DIFF
--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -289,7 +289,6 @@ class _ShowDepsDialog extends StatefulWidget {
 }
 
 class _ShowDepsDialogState extends State<_ShowDepsDialog> {
-  bool _isExpanded = false;
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -327,14 +326,11 @@ class _ShowDepsDialogState extends State<_ShowDepsDialog> {
             ),
             YaruExpandable(
               expandButtonPosition: YaruExpandableButtonPosition.start,
-              onChange: (isExpanded) =>
-                  setState(() => _isExpanded = isExpanded),
               header: MouseRegion(
                 cursor: SystemMouseCursors.click,
                 child: Text(
                   context.l10n.dependencies,
-                  style: TextStyle(
-                    color: _isExpanded ? null : theme.primaryColor,
+                  style: const TextStyle(
                     fontWeight: FontWeight.w500,
                   ),
                 ),


### PR DESCRIPTION
Don't change color when expanded. From design mockup here: https://github.com/ubuntu-flutter-community/software/issues/739#issuecomment-1379080564

@anasereijo ?

![image](https://user-images.githubusercontent.com/3986894/219982487-14ca84bd-8666-42df-a982-bd069eeb36c9.png)
