### PR TITLE
Bulk refresh

### DIFF
--- a/lib/app/app_model.dart
+++ b/lib/app/app_model.dart
@@ -34,7 +34,7 @@ class AppModel extends SafeChangeNotifier {
   );
 
   final SnapService _snapService;
-  Map<Snap, SnapdChange> get snapChanges => _snapService.snapChanges;
+  Map<String, SnapdChange> get snapChanges => _snapService.snapChanges;
   StreamSubscription<bool>? _snapChangesSub;
 
   final AppstreamService _appstreamService;

--- a/lib/app/collection/collection_model.dart
+++ b/lib/app/collection/collection_model.dart
@@ -129,29 +129,13 @@ class CollectionModel extends SafeChangeNotifier {
   Future<void> refreshAllSnapsWithUpdates({
     required String doneMessage,
   }) async {
-    await _snapService.authorize();
     if (snapsWithUpdate.isEmpty) return;
-
-    final firstSnap = snapsWithUpdate.first;
-    _snapService
-        .refresh(
-      snap: firstSnap,
+    await _snapService.authorize();
+    await _snapService.refreshMany(
+      snaps: snapsWithUpdate,
       message: doneMessage,
-      channel: firstSnap.channel,
-      confinement: firstSnap.confinement,
-    )
-        .then((_) {
-      notifyListeners();
-      for (var snap in snapsWithUpdate.skip(1)) {
-        _snapService.refresh(
-          snap: snap,
-          message: doneMessage,
-          confinement: snap.confinement,
-          channel: snap.channel,
-        );
-        notifyListeners();
-      }
-    });
+    );
+    notifyListeners();
   }
 
   SnapSort _snapSort = SnapSort.name;

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -217,6 +217,15 @@ class SnapService {
     return await findLocalSnap(snap.name);
   }
 
+  Future<void> refreshMany({
+    required List<Snap> snaps,
+    required String message,
+  }) async {
+    final changeId =
+        await _snapDClient.refreshMany(snaps.map((e) => e.name).toList());
+    await _addChange(changeId, message);
+  }
+
   Future<Map<SnapPlug, bool>> loadPlugs(Snap localSnap) async {
     final Map<SnapPlug, bool> plugs = {};
 
@@ -311,13 +320,9 @@ class SnapService {
     required List<Snap> snaps,
   }) async {
     await authorize();
-    for (var snap in snaps) {
-      await refresh(
-        snap: snap,
-        message: doneMessage,
-        confinement: snap.confinement,
-        channel: snap.channel,
-      );
-    }
+    await refreshMany(
+      snaps: snaps,
+      message: doneMessage,
+    );
   }
 }

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -314,15 +314,4 @@ class SnapService {
   Future<void> loadSnapsWithUpdate() async {
     _snapsWithUpdate = await _snapDClient.find(filter: SnapFindFilter.refresh);
   }
-
-  Future<void> refreshAll({
-    required String doneMessage,
-    required List<Snap> snaps,
-  }) async {
-    await authorize();
-    await refreshMany(
-      snaps: snaps,
-      message: doneMessage,
-    );
-  }
 }

--- a/test/services/snap_service_test.dart
+++ b/test/services/snap_service_test.dart
@@ -32,7 +32,7 @@ void main() {
       () => mockNotificationsClient.notify(
         any(),
         body: any(named: 'body'),
-        appName: snap1.name,
+        appName: 'Snap Store',
         appIcon: 'snap-store',
         hints: any(named: 'hints'),
       ),
@@ -223,7 +223,7 @@ void main() {
       () => mockNotificationsClient.notify(
         any(),
         body: any(named: 'body'),
-        appName: snap1.name,
+        appName: 'Snap Store',
         appIcon: 'snap-store',
         hints: any(named: 'hints'),
       ),
@@ -251,7 +251,7 @@ void main() {
       () => mockNotificationsClient.notify(
         any(),
         body: any(named: 'body'),
-        appName: snap1.name,
+        appName: 'Snap Store',
         appIcon: 'snap-store',
         hints: any(named: 'hints'),
       ),
@@ -311,7 +311,7 @@ void main() {
       () => mockNotificationsClient.notify(
         any(),
         body: any(named: 'body'),
-        appName: snap1.name,
+        appName: 'Snap Store',
         appIcon: 'snap-store',
         hints: any(named: 'hints'),
       ),


### PR DESCRIPTION
This makes use of `refreshMany` in snapd.dart to bulk refresh multiple snaps at once.
Note that it's necessary to change how snap changes are tracked in `SnapService`: a single `SnapChange` can affect multiple snaps, so using a `Map<Snap, SnapChange>` doesn't make sense any more. This also has an effect on the notifications - they now use 'Software Store' as `appName` rather than the name of the snap that has been changed, since there can be multiple now.

It would be great to test this with real-world snap updates before merging, even though I've added a unit test.

Fix #1074