### PR TITLE
Update from yaru

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,10 +55,10 @@ dependencies:
   url_launcher: ^6.1.2
   version: ^3.0.2
   xdg_icons: ^0.0.1
-  yaru: ^0.5.1
-  yaru_colors: ^0.1.3
+  yaru: ^0.5.4
+  yaru_colors: ^0.1.6
   yaru_icons: ^1.0.3
-  yaru_widgets: ^2.1.0
+  yaru_widgets: ^2.1.1
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   url_launcher: ^6.1.2
   version: ^3.0.2
   xdg_icons: ^0.0.1
-  yaru: ^0.5.4
+  yaru: ^0.5.5
   yaru_colors: ^0.1.6
   yaru_icons: ^1.0.3
   yaru_widgets: ^2.1.1


### PR DESCRIPTION
A request from the installer team led to stronger borders and to popupmenu buttons (dropdowns) having the same border as outlined buttons

| Before | After |
| - | - |
|![grafik](https://user-images.githubusercontent.com/15329494/220879719-0929aba9-f5e8-4390-9198-d1309f570a1f.png)|![grafik](https://user-images.githubusercontent.com/15329494/220879081-d6566d07-cf2e-4c0c-847d-b27735e9fd6d.png)|
|![grafik](https://user-images.githubusercontent.com/15329494/220879754-260643ab-23a1-4db1-b4e3-436349d6de95.png)|![grafik](https://user-images.githubusercontent.com/15329494/220879175-a8bebc89-2b79-49c3-aecd-a7e3c93c236d.png)|

Updating yaru and yaru_widgets here will thus also change those styles here.

Is this okay for you @anasereijo @Zoospora @madsrh ?