### PR TITLE
Bump dependency on intl

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   glib: 0.0.1
   gtk_application: ^0.0.3
   handy_window: ^0.3.0
-  intl: ^0.17.0
+  intl: ^0.18.0
   launcher_entry: ^0.1.0
   liquid_progress_indicator: ^0.4.0
   meta: ^1.7.0


### PR DESCRIPTION
```$ flutter pub get
Resolving dependencies... (4.6s)
Because software depends on flutter_localizations from sdk which depends on intl 0.18.0, intl 0.18.0 is required.
So, because software depends on intl ^0.17.0, version solving failed.
```