### PR TITLE
Cancel `refreshAll` if first PolKit authentication request is cancelled

### DIFF
--- a/lib/app/collection/collection_model.dart
+++ b/lib/app/collection/collection_model.dart
@@ -126,33 +126,8 @@ class CollectionModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> refreshAllSnapsWithUpdates({
-    required String doneMessage,
-  }) async {
-    await _snapService.authorize();
-    if (snapsWithUpdate.isEmpty) return;
-
-    final firstSnap = snapsWithUpdate.first;
-    _snapService
-        .refresh(
-      snap: firstSnap,
-      message: doneMessage,
-      channel: firstSnap.channel,
-      confinement: firstSnap.confinement,
-    )
-        .then((_) {
-      notifyListeners();
-      for (var snap in snapsWithUpdate.skip(1)) {
-        _snapService.refresh(
-          snap: snap,
-          message: doneMessage,
-          confinement: snap.confinement,
-          channel: snap.channel,
-        );
-        notifyListeners();
-      }
-    });
-  }
+  Future<void> refreshAllSnapsWithUpdates({required String doneMessage}) =>
+      _snapService.refreshAll(doneMessage: doneMessage);
 
   SnapSort _snapSort = SnapSort.name;
   SnapSort get snapSort => _snapSort;

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -212,6 +212,8 @@ class SnapService {
           _refreshErrorController.add(
             '${snap.name} has running apps, close ${snap.name} to update.',
           );
+        } else if (e.kind == 'auth-cancelled') {
+          rethrow;
         }
       }
     }

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -312,10 +312,24 @@ class SnapService {
 
   Future<void> refreshAll({
     required String doneMessage,
-    required List<Snap> snaps,
   }) async {
     await authorize();
-    for (var snap in snaps) {
+    if (snapsWithUpdate.isEmpty) return;
+
+    final firstSnap = snapsWithUpdate.first;
+    try {
+      await refresh(
+        snap: firstSnap,
+        message: doneMessage,
+        channel: firstSnap.channel,
+        confinement: firstSnap.confinement,
+      );
+    } on SnapdException catch (e) {
+      if (e.kind == 'auth-cancelled') {
+        return;
+      }
+    }
+    for (var snap in snapsWithUpdate.skip(1)) {
       await refresh(
         snap: snap,
         message: doneMessage,


### PR DESCRIPTION
Since https://github.com/ubuntu-flutter-community/software/pull/1105 would hide update information of the individual snaps, let's instead keep the current mechanism where we refresh each snap individually and solve the auth dialog issue by checking for an exception.

Fix #1074