### PR TITLE
Dependencies styling

### DIFF
--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -227,37 +227,33 @@ class _PackagePageState extends State<PackagePage> {
       initialized: initialized,
       child: YaruExpandable(
         header: ExpandableContainerTitle(
-          '${context.l10n.dependencies} (${model.missingDependencies.length})',
+          '${context.l10n.dependencies} (${model.missingDependencies.length}) - ${model.missingDependencies.map((d) => d.size).sum.formatByteSize()}',
         ),
         child: Padding(
           padding: const EdgeInsets.only(top: 10),
           child: Column(
             children: model.missingDependencies
-                    .map<Widget>(
-                      (e) => ListTile(
-                        title: Text(e.id.name),
-                        subtitle: e.summary != null ? Text(e.summary!) : null,
-                        leading: Icon(
-                          YaruIcons.package_deb,
-                          color: theme.colorScheme.onSurface,
-                        ),
-                        trailing: Text(e.size.formatByteSize()),
-                      ),
-                    )
-                    .toList() +
-                [
-                  const Divider(),
-                  ListTile(
-                    title: const Text('Total'),
-                    leading: const SizedBox(),
+                .map<Widget>(
+                  (e) => ListTile(
+                    title: Text(e.id.name),
+                    subtitle: e.summary != null
+                        ? Text(
+                            e.summary!,
+                            style: TextStyle(
+                              color: Theme.of(context).hintColor,
+                            ),
+                          )
+                        : null,
+                    leading: Icon(
+                      YaruIcons.package_deb,
+                      color: theme.colorScheme.onSurface,
+                    ),
                     trailing: Text(
-                      model.missingDependencies
-                          .map((d) => d.size)
-                          .sum
-                          .formatByteSize(),
+                      e.size.formatByteSize(),
                     ),
                   ),
-                ],
+                )
+                .toList(),
           ),
         ),
       ),
@@ -310,7 +306,7 @@ class _ShowDepsDialogState extends State<_ShowDepsDialog> {
     final theme = Theme.of(context);
     return AlertDialog(
       title: SizedBox(
-        width: 500,
+        width: 400,
         child: YaruDialogTitleBar(
           title: Text(context.l10n.dependencies),
         ),
@@ -329,7 +325,6 @@ class _ShowDepsDialogState extends State<_ShowDepsDialog> {
                   widget.dependencies.map((d) => d.size).sum.formatByteSize(),
                   widget.packageName,
                 ),
-                style: theme.textTheme.bodyLarge,
               ),
             ),
             Padding(
@@ -357,10 +352,17 @@ class _ShowDepsDialogState extends State<_ShowDepsDialog> {
                     for (var d in widget.dependencies)
                       ListTile(
                         title: Text(d.id.name),
-                        subtitle: Text(d.size.formatByteSize()),
-                        leading: const Icon(
-                          YaruIcons.package_deb,
+                        subtitle: Text(
+                          d.summary ?? context.l10n.unknown,
+                          style: TextStyle(
+                            color: Theme.of(context).hintColor,
+                          ),
                         ),
+                        leading: Icon(
+                          YaruIcons.package_deb,
+                          color: theme.colorScheme.onSurface,
+                        ),
+                        trailing: Text(d.size.formatByteSize()),
                       )
                   ],
                 ),


### PR DESCRIPTION
For something like _Inkscape_ where there are 149 dependencies, it takes forever to scroll to the total size a the bottom, so I've added the size to the expander title. Maybe it's too much info 🤷‍♂️ 

Piggybacking on the work by @d-loose I've added summary to dialog + color tweaks for summary text and icon.

![image](https://user-images.githubusercontent.com/3986894/222091924-5697ff1b-58b4-4e9b-bf5c-555f85c40147.png)


![image](https://user-images.githubusercontent.com/3986894/222090696-42164409-8f84-49fb-9383-f97f66198a90.png)
