### PR TITLE
use desktop launch interface

### DIFF
--- a/lib/app/collection/simple_snap_controls.dart
+++ b/lib/app/collection/simple_snap_controls.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:snapcraft_launcher/snapcraft_launcher.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/collection/simple_snap_model.dart';
 import 'package:software/app/common/constants.dart';
@@ -43,6 +44,7 @@ class SimpleSnapControls extends StatelessWidget {
       create: (_) {
         return SimpleSnapModel(
           getService<SnapService>(),
+          getService<PrivilegedDesktopLauncher>(),
           snap: snap,
         )..init();
       },
@@ -106,11 +108,9 @@ class SimpleSnapControls extends StatelessWidget {
                         : null,
                   ),
                 ),
-              if (model.snap.type == 'app' &&
-                  (model.snap.apps.length == 1) &&
-                  enabled)
+              if (model.isLaunchable && enabled)
                 OutlinedButton(
-                  onPressed: () => model.open(),
+                  onPressed: model.open,
                   child: Text(
                     context.l10n.open,
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 import 'package:gtk_application/gtk_application.dart';
 import 'package:launcher_entry/launcher_entry.dart';
 import 'package:packagekit/packagekit.dart';
+import 'package:snapcraft_launcher/snapcraft_launcher.dart';
 import 'package:snapd/snapd.dart';
 import 'package:software/app/app.dart';
 import 'package:software/services/appstream/appstream_service.dart';
@@ -65,6 +66,11 @@ Future<void> main(List<String> args) async {
 
   registerService<OdrsService>(
     () => OdrsService(Uri.https('odrs.gnome.org')),
+    dispose: (s) => s.close(),
+  );
+
+  registerService<PrivilegedDesktopLauncher>(
+    () => PrivilegedDesktopLauncher(),
     dispose: (s) => s.close(),
   );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   quiver: ^3.1.0
   safe_change_notifier: ^0.2.0
   shimmer: ^2.0.0
+  snapcraft_launcher: ^0.1.0
   snapd: ^0.4.7
   snowball_stemmer: ^0.1.0
   synchronized: ^3.0.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   package_info_plus: ^1.4.2
   packagekit: ^0.2.6
   palette_generator: ^0.3.3
+  path: ^1.8.2
   provider: ^6.0.2
   quiver: ^3.1.0
   safe_change_notifier: ^0.2.0
@@ -69,7 +70,6 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   mocktail: ^0.3.0
-  path: ^1.8.0
 
 flutter:
   uses-material-design: true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,6 +61,7 @@ apps:
     plugs:
       - appstream-metadata
       - desktop
+      - desktop-launch
       - desktop-legacy
       - network
       - network-manager


### PR DESCRIPTION
Uses [snapcraft_launcher.dart](https://github.com/d-loose/snapcraft_launcher.dart) to launch desktop applications from other snaps.
Fix #209