### PR TITLE
ExplorePage: show top rated apps

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -66,7 +66,7 @@ class App extends StatelessWidget {
               getService<AppstreamService>(),
               getService<SnapService>(),
               getService<PackageService>(),
-            )..init(),
+            ),
           )
         ],
         child: const App(),
@@ -141,6 +141,14 @@ class __AppState extends State<_App> {
         barrierDismissible: false,
         builder: (c) => const CloseWindowConfirmDialog(),
       ).then((result) => result ?? false);
+    });
+
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (mounted) {
+        context.read<ExploreModel>().init().then((value) {
+          context.read<ExploreModel>().findTopRatedApps();
+        });
+      }
     });
   }
 

--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -273,4 +273,19 @@ class ExploreModel extends SafeChangeNotifier {
       searchResult = appFindings;
     }
   }
+
+  List<AppFinding>? _topRatedApps;
+  List<AppFinding>? get topRatedApps => _topRatedApps;
+  Future<void> findTopRatedApps() async {
+    final topApps = <AppFinding>[];
+    final snaps =
+        await _snapService.findSnapsByQuery(searchQuery: ' ', sectionName: '');
+    for (var s in snaps) {
+      topApps.add(AppFinding(snap: s));
+    }
+
+    _topRatedApps = topApps;
+
+    notifyListeners();
+  }
 }

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -114,6 +114,8 @@ class _ExplorePageState extends State<ExplorePage> {
     final search = context.select((ExploreModel m) => m.search);
     final errorMessage = context.select((AppModel m) => m.errorMessage);
 
+    final topRatedApps = context.watch<ExploreModel>().topRatedApps;
+
     return Scaffold(
       appBar: YaruWindowTitleBar(
         leading: const SizedBox(width: kLeadingGap),
@@ -155,8 +157,12 @@ class _ExplorePageState extends State<ExplorePage> {
                       ),
                     )
                   : StartPage(
+                      topRatedApps: topRatedApps ?? [],
                       apps: startPageApps[widget.section],
                       snapSection: widget.section,
+                      gameApps: widget.section == SnapSection.all
+                          ? startPageApps[SnapSection.games]
+                          : null,
                     )),
     );
   }

--- a/lib/app/explore/start_page.dart
+++ b/lib/app/explore/start_page.dart
@@ -16,25 +16,35 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:software/app/common/app_banner.dart';
 import 'package:software/app/common/app_finding.dart';
+import 'package:software/app/common/app_rating.dart';
 import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/loading_banner_grid.dart';
+import 'package:software/app/common/rating_model.dart';
 import 'package:software/app/common/snap/snap_section.dart';
 import 'package:software/app/explore/section_banner.dart';
 import 'package:software/app/explore/section_grid.dart';
+import 'package:software/l10n/l10n.dart';
 import 'package:software/snapx.dart';
 import 'package:yaru_colors/yaru_colors.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class StartPage extends StatefulWidget {
   const StartPage({
     super.key,
     this.apps,
     required this.snapSection,
+    this.topRatedApps,
+    this.gameApps,
   });
 
   final List<AppFinding>? apps;
+  final List<AppFinding>? topRatedApps;
+  final List<AppFinding>? gameApps;
+
   final SnapSection snapSection;
 
   @override
@@ -49,7 +59,7 @@ class _StartPageState extends State<StartPage> {
   void initState() {
     super.initState();
 
-    _amount = 60;
+    _amount = 20;
     _controller = ScrollController();
 
     _controller.addListener(() {
@@ -68,9 +78,12 @@ class _StartPageState extends State<StartPage> {
       controller: _controller,
       child: Column(
         children: [
-          _TeaserPage(
+          _Page(
             snapSection: widget.snapSection,
             apps: widget.apps,
+            amount: _amount,
+            topRatedApps: widget.topRatedApps,
+            gameApps: widget.gameApps,
           ),
         ],
       ),
@@ -78,17 +91,46 @@ class _StartPageState extends State<StartPage> {
   }
 }
 
-class _TeaserPage extends StatelessWidget {
-  const _TeaserPage({
+class _Page extends StatelessWidget {
+  const _Page({
     required this.snapSection,
     this.apps,
+    this.amount = 10,
+    this.topRatedApps,
+    this.gameApps,
   });
 
   final SnapSection snapSection;
   final List<AppFinding>? apps;
+  final int amount;
+  final List<AppFinding>? topRatedApps;
+  final List<AppFinding>? gameApps;
 
   @override
   Widget build(BuildContext context) {
+    final getRating = context.read<RatingModel>().getRating;
+
+    var tops = <AppFinding, double>{};
+
+    for (var app in topRatedApps ?? <AppFinding>[]) {
+      if (app.snap != null) {
+        final rating = getRating(app.snap!.ratingId);
+        if (rating != null && rating.total! > 500) {
+          tops.putIfAbsent(app, () => rating.average!);
+        }
+      }
+    }
+
+    tops = Map.fromEntries(
+      tops.entries.toList()
+        ..sort((e1, e2) {
+          return e2.value.compareTo(e1.value);
+        }),
+    );
+
+    var showTopApps =
+        snapSection == SnapSection.all && topRatedApps?.isNotEmpty == true;
+
     final appsWithIcons =
         apps?.where((app) => app.snap?.iconUrl != null).toList();
     AppFinding? bannerApp;
@@ -109,33 +151,95 @@ class _TeaserPage extends StatelessWidget {
       );
     }
 
-    return Column(
-      children: [
-        SectionBanner(
-          gradientColors: snapSection.colors.map((e) => Color(e)).toList(),
-          apps: [bannerApp, bannerApp2, bannerApp3],
-          section: snapSection,
-        ),
-        snapSection == SnapSection.games
-            ? GridView(
-                shrinkWrap: true,
-                padding: kGridPadding,
-                physics: const NeverScrollableScrollPhysics(),
-                gridDelegate: kImageGridDelegate,
-                children: [
-                  for (final app in apps
-                          ?.where((a) => a.snap!.bannerUrl != null)
-                          .toList() ??
-                      <AppFinding>[])
-                    AppImageBanner(snap: app.snap!),
-                ],
-              )
-            : SectionGrid(
-                apps: apps ?? [],
-                take: 20,
-                skip: 3,
+    final allChildren = [
+      SectionBanner(
+        gradientColors: snapSection.colors.map((e) => Color(e)).toList(),
+        apps: [bannerApp, bannerApp2, bannerApp3],
+        section: snapSection,
+      ),
+      if (showTopApps)
+        Padding(
+          padding: const EdgeInsets.only(
+            left: kYaruPagePadding,
+            right: kYaruPagePadding,
+            bottom: kYaruPagePadding,
+          ),
+          child: Row(
+            children: [
+              Text(
+                context.l10n.topRatedSnaps,
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(fontWeight: FontWeight.w100),
               ),
-      ],
+            ],
+          ),
+        ),
+      if (showTopApps)
+        SectionGrid(apps: tops.entries.take(6).map((e) => e.key).toList()),
+      if (gameApps?.isNotEmpty == true)
+        Padding(
+          padding: const EdgeInsets.all(kYaruPagePadding),
+          child: Row(
+            children: [
+              Text(
+                SnapSection.games.slogan(context.l10n),
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(fontWeight: FontWeight.w100),
+              ),
+            ],
+          ),
+        ),
+      if (gameApps?.isNotEmpty == true)
+        GridView(
+          shrinkWrap: true,
+          padding: kGridPadding,
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: kImageGridDelegate,
+          children: [
+            for (final app in gameApps
+                    ?.where((a) => a.snap!.bannerUrl != null)
+                    .toList()
+                    .take(6) ??
+                <AppFinding>[])
+              AppImageBanner(snap: app.snap!),
+          ],
+        ),
+    ];
+    return Column(
+      children: snapSection == SnapSection.all
+          ? allChildren
+          : [
+              SectionBanner(
+                gradientColors:
+                    snapSection.colors.map((e) => Color(e)).toList(),
+                apps: [bannerApp, bannerApp2, bannerApp3],
+                section: snapSection,
+              ),
+              snapSection == SnapSection.games
+                  ? GridView(
+                      shrinkWrap: true,
+                      padding: kGridPadding,
+                      physics: const NeverScrollableScrollPhysics(),
+                      gridDelegate: kImageGridDelegate,
+                      children: [
+                        for (final app in apps
+                                ?.where((a) => a.snap!.bannerUrl != null)
+                                .toList()
+                                .take(6) ??
+                            <AppFinding>[])
+                          AppImageBanner(snap: app.snap!),
+                      ],
+                    )
+                  : SectionGrid(
+                      apps: apps ?? [],
+                      take: amount,
+                      skip: 3,
+                    ),
+            ],
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -67,7 +67,7 @@
   "@featuredSlogan": {},
   "financeSlogan": "Finanz- und Kalkulations-Apps",
   "@financeSlogan": {},
-  "gamesSlogan": "Spiele und Gaming",
+  "gamesSlogan": "Alles für deinen Gaming-Abend",
   "@gamesSlogan": {},
   "healthAndFitnessSlogan": "Gesundheit und Fitness",
   "@healthAndFitnessSlogan": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -33,7 +33,7 @@
   "entertainmentSlogan": "Home entertainment tools",
   "featuredSlogan": "Our featured apps",
   "financeSlogan": "Financial tools",
-  "gamesSlogan": "Games and gaming",
+  "gamesSlogan": "Everything for your game night",
   "healthAndFitnessSlogan": "Health and Fitness",
   "musicAndAudioSlogan": "Music and Audio",
   "newsAndWeatherSlogan": "News and Weather",
@@ -226,5 +226,7 @@
   "report": "Report",
   "reportAbuse": "Report abuse",
   "reportReviewDialogTitle": "Report review",
-  "reportReviewDialogBody": "You can report a review for abusive, rude, or discriminatory behavior. Once reported, a review will be hidden until it has been checked by an administrator."
+  "reportReviewDialogBody": "You can report a review for abusive, rude, or discriminatory behavior. Once reported, a review will be hidden until it has been checked by an administrator.",
+  "topRatedSnaps": "Top rated snaps",
+  "topRatedApps": "Top rated apps"
 }


### PR DESCRIPTION
App starts with the default size
![grafik](https://user-images.githubusercontent.com/15329494/223184363-191e450b-297c-4805-adbc-4c6712ac5eba.png)

Scrolling further:
![grafik](https://user-images.githubusercontent.com/15329494/223184509-56206017-66b2-44a9-8d55-78f948b4a25a.png)

Note to @d-loose : does not affect the other pages, thought this needed some weird tricks. When we are sure if and how many shortcuts we want to have, we might want to just settle down to

- ExplorePage
- GamingPage
- etc

and we can remove this weird explorepage -> startpage -> page hierarchy

Draft until we got some feedback from the ana² or oliver

Fixes #1096