### PR TITLE
Linkcolor blue - again

### DIFF
--- a/lib/app/collection/package_update_dialog.dart
+++ b/lib/app/collection/package_update_dialog.dart
@@ -28,6 +28,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 import 'package:software/app/common/border_container.dart';
+import 'package:software/app/common/link.dart';
 
 class PackageUpdateDialog extends StatefulWidget {
   const PackageUpdateDialog({
@@ -110,8 +111,7 @@ class _PackageUpdateDialogState extends State<PackageUpdateDialog> {
               onTapLink: (text, href, title) =>
                   href != null ? launchUrl(Uri.parse(href)) : null,
               styleSheet: MarkdownStyleSheet(
-                p: Theme.of(context).textTheme.bodyMedium,
-                a: TextStyle(color: Theme.of(context).primaryColor),
+                a: TextStyle(color: context.linkColor),
               ),
             ),
           ),

--- a/lib/app/common/app_page/app_description.dart
+++ b/lib/app/common/app_page/app_description.dart
@@ -22,6 +22,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 import '../expandable_title.dart';
+import 'package:software/app/common/link.dart';
 
 class AppDescription extends StatelessWidget {
   const AppDescription({super.key, required this.description});
@@ -46,8 +47,7 @@ class AppDescription extends StatelessWidget {
           onTapLink: (text, href, title) =>
               href != null ? launchUrl(Uri.parse(href)) : null,
           styleSheet: MarkdownStyleSheet(
-            p: Theme.of(context).textTheme.bodyMedium,
-            a: TextStyle(color: Theme.of(context).primaryColor),
+            a: TextStyle(color: context.linkColor),
             textAlign: WrapAlignment.start,
           ),
         ),

--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -36,6 +36,7 @@ import 'package:software/l10n/l10n.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 import '../expandable_title.dart';
+import 'package:yaru_colors/yaru_colors.dart';
 
 class AppPage extends StatefulWidget {
   const AppPage({
@@ -184,17 +185,27 @@ class _AppPageState extends State<AppPage> {
     );
 
     void onShare(AppData appData) {
+      final colorScheme = Theme.of(context).colorScheme;
+      final linkColorInvert = colorScheme.brightness == Brightness.light
+          ? YaruColors.blue[500]!
+          : YaruColors.blue[700]!;
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               Text('${context.l10n.copiedToClipboard}: '),
-              Link(url: appData.website, linkText: appData.website)
+              Link(
+                url: appData.website,
+                linkText: appData.website,
+                textStyle: TextStyle(color: linkColorInvert),
+              ),
             ],
           ),
         ),
       );
+
       Clipboard.setData(ClipboardData(text: appData.website));
     }
 

--- a/lib/app/common/link.dart
+++ b/lib/app/common/link.dart
@@ -18,6 +18,7 @@
 import 'package:flutter/material.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:yaru_colors/yaru_colors.dart';
 
 class Link extends StatelessWidget {
   const Link({
@@ -44,8 +45,14 @@ class Link extends StatelessWidget {
             Theme.of(context)
                 .textTheme
                 .bodyMedium
-                ?.copyWith(color: Theme.of(context).colorScheme.primary),
+                ?.copyWith(color: context.linkColor),
       ),
     );
   }
+}
+
+extension LinkColor on BuildContext {
+  Color get linkColor => Theme.of(this).brightness == Brightness.light
+      ? YaruColors.blue[700]!
+      : YaruColors.blue[500]!;
 }

--- a/lib/app/settings/settings_page.dart
+++ b/lib/app/settings/settings_page.dart
@@ -343,9 +343,7 @@ class _AboutDialog extends StatelessWidget {
                                       .textTheme
                                       .bodyMedium
                                       ?.copyWith(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary,
+                                        color: context.linkColor,
                                       ),
                                 ),
                                 const SizedBox(
@@ -353,7 +351,7 @@ class _AboutDialog extends StatelessWidget {
                                 ),
                                 Icon(
                                   YaruIcons.external_link,
-                                  color: Theme.of(context).primaryColor,
+                                  color: context.linkColor,
                                   size: 18,
                                 )
                               ],
@@ -376,8 +374,7 @@ class _AboutDialog extends StatelessWidget {
                         onTapLink: (text, href, title) =>
                             href != null ? launchUrl(Uri.parse(href)) : null,
                         styleSheet: MarkdownStyleSheet(
-                          p: Theme.of(context).textTheme.bodyMedium,
-                          a: TextStyle(color: Theme.of(context).primaryColor),
+                          a: TextStyle(color: context.linkColor),
                         ),
                       );
                     } else {


### PR DESCRIPTION
Continuing https://github.com/ubuntu-flutter-community/software/pull/1094/files because of the installer using blue links https://github.com/canonical/ubuntu-desktop-installer/pull/1486 and also ofc the Vanilla framework, here's the return of the blue links.

This sounded like low hanging fruit, but got more advanced than I had anticipated, so there might be a better way of doing this 🤷‍♂️ 


![image](https://user-images.githubusercontent.com/3986894/224473028-d75959e6-55dc-480a-83ee-4acd6536afca.png)

![image](https://user-images.githubusercontent.com/3986894/224473039-85c3dad6-b3cb-4235-82fb-4b19d3f48597.png)

![image](https://user-images.githubusercontent.com/3986894/224473188-1d43c646-b750-4c07-94b0-6d24b7223cf2.png)

![image](https://user-images.githubusercontent.com/3986894/224473194-2d9a005e-e59f-4dbc-acc1-3a592671e160.png)

![image](https://user-images.githubusercontent.com/3986894/224473178-b3f0fe4b-4b6e-4a61-b96f-c8c3c08abb63.png)

![image](https://user-images.githubusercontent.com/3986894/224473181-10bb52db-9351-4ea1-8784-52471a6fcd62.png)

![image](https://user-images.githubusercontent.com/3986894/224473202-167f1b16-18e8-4ccb-8d8d-8debdac55171.png)

![image](https://user-images.githubusercontent.com/3986894/224473208-ff2fb52b-fb6c-4fa2-a56e-99cdd99f3a79.png)


