### PR TITLE
More readable publisherName for app_banners

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -232,8 +232,7 @@ class SearchBannerSubtitle extends StatelessWidget {
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
-                  fontStyle: FontStyle.italic,
-                  color: theme.colorScheme.onSurface.withOpacity(0.5),
+                  color: theme.hintColor,
                 ),
               ),
             ),

--- a/lib/app/common/app_page/publisher_name.dart
+++ b/lib/app/common/app_page/publisher_name.dart
@@ -50,10 +50,7 @@ class PublisherName extends StatelessWidget {
       publisherName,
       style: Theme.of(context).textTheme.bodyMedium!.copyWith(
             fontSize: height,
-            fontStyle: enhanceChildText ? FontStyle.italic : FontStyle.normal,
-            color: enhanceChildText
-                ? theme.colorScheme.onSurface.withOpacity(0.7)
-                : null,
+            color: enhanceChildText ? theme.hintColor : null,
           ),
       overflow: TextOverflow.ellipsis,
     );


### PR DESCRIPTION
Just a suggestion: a very small change, but I think this is easier to read. WDYT? @anasereijo @Jupi007 @Feichtmeier 

- removed _italic_
- used Hintcolor

I wonder if we should remove the italic from the app page also?

### Before:
![image](https://user-images.githubusercontent.com/3986894/224484245-028a293d-597b-43c0-b551-e036a43ca34e.png)
![image](https://user-images.githubusercontent.com/3986894/224484534-f2f27f75-9987-4c52-9e15-ddb37bedaa7d.png)

### After:
![image](https://user-images.githubusercontent.com/3986894/224484272-5090ea62-86b6-4386-ac71-623f509242bc.png)
![image](https://user-images.githubusercontent.com/3986894/224484552-cf047824-55db-44b7-a7f7-ab8fd4e222e4.png)

