### PR TITLE
Appformat popup font size

### DIFF
--- a/lib/app/common/app_format_popup.dart
+++ b/lib/app/common/app_format_popup.dart
@@ -95,7 +95,9 @@ class AppFormatPopup extends StatelessWidget {
             )
         ],
         onSelected: onSelected,
-        child: Text(appFormat.localize(context.l10n)),
+        child: Text(
+          appFormat.localize(context.l10n),
+        ),
       ),
     );
   }
@@ -126,6 +128,7 @@ class MultiAppFormatPopup extends StatelessWidget {
               value: appFormat,
               checked: selectedAppFormats.contains(appFormat),
               child: Text(
+                style: Theme.of(context).textTheme.bodyMedium,
                 appFormat.localize(context.l10n),
               ),
             ),


### PR DESCRIPTION
The two dropdowns or popups should have the same font size:

### Before:
![image](https://user-images.githubusercontent.com/3986894/224515090-2c326478-d3a7-4123-b931-578f9083c649.png)


### After:
![image](https://user-images.githubusercontent.com/3986894/224515084-8402c411-48a6-4713-905b-beee33ab6ccc.png)
