### PR TITLE
removed unnecessary sized box

### DIFF
--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -118,9 +118,6 @@ class _AppReviewsState extends State<AppReviews> {
               onVote: widget.onVote,
               onFlag: widget.onFlag,
             ),
-            const SizedBox(
-              height: kYaruPagePadding,
-            ),
             Row(
               children: [
                 OutlinedButton(


### PR DESCRIPTION
Removes unnecessary space between the review carousel and the "show all reviews" button.

Before:

![Screenshot from 2023-03-13 03-16-19](https://user-images.githubusercontent.com/73116038/224600192-a755da73-1b68-4b7e-a2d6-d303b204f10a.png)

After:

![Screenshot from 2023-03-13 03-15-48](https://user-images.githubusercontent.com/73116038/224600200-2310ebf7-4a26-4292-b4d3-60b2494d846a.png)

