### PR TITLE
Remove themeTile artifacts

### DIFF
--- a/lib/app/settings/theme_tile.dart
+++ b/lib/app/settings/theme_tile.dart
@@ -11,7 +11,7 @@ class ThemeTile extends StatelessWidget {
   Widget build(BuildContext context) {
     const height = 100.0;
     const width = 150.0;
-    var borderRadius2 = BorderRadius.circular(10);
+    var borderRadius2 = BorderRadius.circular(12);
     var lightContainer = Container(
       decoration: BoxDecoration(
         color: Colors.white,

--- a/lib/app/settings/theme_tile.dart
+++ b/lib/app/settings/theme_tile.dart
@@ -11,7 +11,7 @@ class ThemeTile extends StatelessWidget {
   Widget build(BuildContext context) {
     const height = 100.0;
     const width = 150.0;
-    var borderRadius2 = BorderRadius.circular(12);
+    var borderRadius2 = BorderRadius.circular(10);
     var lightContainer = Container(
       decoration: BoxDecoration(
         color: Colors.white,
@@ -47,10 +47,17 @@ class ThemeTile extends StatelessWidget {
             child: themeMode == ThemeMode.system
                 ? Stack(
                     children: [
-                      lightContainer,
                       ClipPath(
                         clipBehavior: Clip.antiAlias,
-                        clipper: _CustomClipPath(
+                        clipper: _CustomClipPathLight(
+                          height: height,
+                          width: width,
+                        ),
+                        child: lightContainer,
+                      ),
+                      ClipPath(
+                        clipBehavior: Clip.antiAlias,
+                        clipper: _CustomClipPathDark(
                           height: height,
                           width: width,
                         ),
@@ -100,8 +107,8 @@ class ThemeTile extends StatelessWidget {
   }
 }
 
-class _CustomClipPath extends CustomClipper<Path> {
-  _CustomClipPath({required this.height, required this.width});
+class _CustomClipPathDark extends CustomClipper<Path> {
+  _CustomClipPathDark({required this.height, required this.width});
 
   final double height;
   final double width;
@@ -110,6 +117,24 @@ class _CustomClipPath extends CustomClipper<Path> {
   Path getClip(Size size) {
     Path path = Path();
     path.lineTo(0, width);
+    path.lineTo(width, height);
+    return path;
+  }
+
+  @override
+  bool shouldReclip(CustomClipper<Path> oldClipper) => false;
+}
+
+class _CustomClipPathLight extends CustomClipper<Path> {
+  _CustomClipPathLight({required this.height, required this.width});
+
+  final double height;
+  final double width;
+
+  @override
+  Path getClip(Size size) {
+    Path path = Path();
+    path.lineTo(width, 0);
     path.lineTo(width, height);
     return path;
   }


### PR DESCRIPTION
You can see the white container bleed through due to anti-aliasing in dark mode.

Before:

![Screenshot from 2023-03-15 05-35-07](https://user-images.githubusercontent.com/73116038/225216887-21f11c44-fff7-4ef3-8ce6-951647023f21.png)


After:

![Screenshot from 2023-03-15 05-34-40](https://user-images.githubusercontent.com/73116038/225216877-5d6121b0-18f9-4d1a-92eb-2415e979f269.png)
