### PR TITLE
Fix swipe animation not resetting

### DIFF
--- a/lib/app/common/app_page/app_swipe_gesture.dart
+++ b/lib/app/common/app_page/app_swipe_gesture.dart
@@ -66,6 +66,7 @@ class _BackGestureState extends State<BackGesture>
   }
 
   void onPanStart(DragStartDetails details, BoxConstraints constraints) {
+    swipeBackController.reset();
     currentExtent = 0;
     xPosition = 0 - _kButtonSize;
     yPosition = (constraints.maxHeight - _kButtonSize) / 2;


### PR DESCRIPTION
Anytime the user would "restart" the gesture before the previous one had concluded, the position of the indicator would be left offscreen. This meant that the new gesture would be in action even though nothing was shown on screen. This PR fixes that :D


Before:

https://user-images.githubusercontent.com/73116038/225236598-de836d60-5061-4284-81c7-9bb718cffaf1.mp4

After:

https://user-images.githubusercontent.com/73116038/225236612-beafe821-4fef-4c05-b6d8-3beafde57ae6.mp4


