### PR TITLE
Use same dateformat for ReleasedAt and InstalledAt

### DIFF
--- a/lib/app/common/snap/snap_model.dart
+++ b/lib/app/common/snap/snap_model.dart
@@ -145,7 +145,7 @@ class SnapModel extends SafeChangeNotifier {
 
   String get selectedChannelReleasedAt =>
       selectableChannels[channelToBeInstalled] != null
-          ? DateFormat.yMd(Platform.localeName)
+          ? DateFormat.yMMMd(Platform.localeName)
               .format(selectableChannels[channelToBeInstalled]!.releasedAt)
           : '';
 


### PR DESCRIPTION
Here's another "death by a thousand paper cuts" fix 😅 Use the same date format for installed and released at date.

I would like to do something (UK/Eur) like `DateFormat('d. MMMM, y')` but that format isn't predefined, so I'm worried that localization won't work 🤷‍♂️

**Before**
![image](https://user-images.githubusercontent.com/3986894/225544268-e43a9ea4-ad72-4c00-85f6-d8164c6665dc.png)

**After**
![image](https://user-images.githubusercontent.com/3986894/225544326-5e41b23c-d6ea-4e73-80b9-9b0f0af607f2.png)



