### PR TITLE
Integration test: fix netplan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           flutter-version: "3.7.x"
       - run: sudo apt update
       - run: sudo apt install -y clang cmake libblkid-dev libglib2.0-dev libgtk-3-dev liblzma-dev network-manager ninja-build packagekit pkg-config polkitd xfce4-notifyd xvfb
-      - run: sudo netplan set renderer=NetworkManager
+      - run: sudo cp integration_test/assets/10-network-manager.yaml /etc/netplan/
       - run: sudo netplan apply
       - run: sudo cp integration_test/assets/packagekit-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/
       - run: sudo cp integration_test/assets/network-manager-ci.pkla /var/lib/polkit-1/localauthority/50-local.d/

--- a/integration_test/assets/10-network-manager.yaml
+++ b/integration_test/assets/10-network-manager.yaml
@@ -1,0 +1,3 @@
+network:
+  version: 2
+  renderer: NetworkManager


### PR DESCRIPTION
Use a config file to use NetworkManager as the default renderer for netplan.
Setting the renderer via the CLI seems to not work anymore. 

Close #1223 