### PR TITLE
chore(deps): odrs ^0.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,9 +40,7 @@ dependencies:
       url: https://github.com/ubuntu-flutter-community/liquid_progress_indicator
       ref: fdeb8de
   meta: ^1.7.0
-  odrs:
-    git:
-      url: https://github.com/ubuntu-flutter-community/odrs.dart
+  odrs: ^0.0.1
   package_info_plus: ^4.0.0
   packagekit: ^0.2.6
   palette_generator: ^0.3.3


### PR DESCRIPTION
Switch to a newly published version to have control over updates and protect against potentially breaking changes.

Includes a fix to set `content-type: application/json` header which may help with occasionally missing app reviews:
- https://github.com/ubuntu-flutter-community/odrs.dart/pull/5