### PR TITLE
fix(explore): filter search results after search

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -42,12 +42,14 @@ class AppBanner extends StatelessWidget {
     required this.showSnap,
     required this.showPackageKit,
     this.enableSearch = true,
+    this.preferSnap = true,
   });
 
   final MapEntry<String, AppFinding> appFinding;
   final bool showSnap;
   final bool showPackageKit;
   final bool enableSearch;
+  final bool preferSnap;
 
   @override
   Widget build(BuildContext context) {
@@ -55,12 +57,19 @@ class AppBanner extends StatelessWidget {
             appFinding.value.appstream != null &&
             showSnap &&
             showPackageKit
-        ? () => SnapPage.push(
-              context: context,
-              snap: appFinding.value.snap!,
-              appstream: appFinding.value.appstream,
-              enableSearch: enableSearch,
-            )
+        ? () => preferSnap
+            ? SnapPage.push(
+                context: context,
+                snap: appFinding.value.snap!,
+                appstream: appFinding.value.appstream,
+                enableSearch: enableSearch,
+              )
+            : PackagePage.push(
+                context,
+                appstream: appFinding.value.appstream!,
+                snap: appFinding.value.snap,
+                enableSearch: enableSearch,
+              )
         : () {
             if (appFinding.value.appstream != null && showPackageKit) {
               PackagePage.push(

--- a/lib/app/explore/explore_page.dart
+++ b/lib/app/explore/explore_page.dart
@@ -103,14 +103,8 @@ class _ExplorePageState extends State<ExplorePage> {
     final handleAppFormat =
         context.select((ExploreModel m) => m.handleAppFormat);
 
-    final showSnap = context.select(
-      (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.snap),
-    );
-    final showPackageKit = context.select(
-      (ExploreModel m) => m.selectedAppFormats.contains(AppFormat.packageKit),
-    );
-
-    final searchResult = context.select((ExploreModel m) => m.searchResult);
+    final filteredSearchResult =
+        context.select((ExploreModel m) => m.filteredSearchResult);
     final search = context.select((ExploreModel m) => m.search);
     final errorMessage = context.select((AppModel m) => m.errorMessage);
 
@@ -146,9 +140,8 @@ class _ExplorePageState extends State<ExplorePage> {
               ? const ExploreErrorPage()
               : (showSearchPage
                   ? SearchPage(
-                      searchResult: searchResult,
-                      showPackageKit: showPackageKit,
-                      showSnap: showSnap,
+                      searchResult: filteredSearchResult,
+                      preferSnap: selectedAppFormats.contains(AppFormat.snap),
                       header: ExploreHeader(
                         selectedSection: selectedSection,
                         enabledAppFormats: enabledAppFormats,

--- a/lib/app/explore/search_page.dart
+++ b/lib/app/explore/search_page.dart
@@ -27,14 +27,12 @@ class SearchPage extends StatefulWidget {
     super.key,
     required this.header,
     this.searchResult,
-    required this.showSnap,
-    required this.showPackageKit,
+    this.preferSnap = true,
   });
 
   final Widget header;
   final Map<String, AppFinding>? searchResult;
-  final bool showSnap;
-  final bool showPackageKit;
+  final bool preferSnap;
 
   @override
   State<SearchPage> createState() => _SearchPageState();
@@ -98,8 +96,9 @@ class _SearchPageState extends State<SearchPage> {
                     widget.searchResult!.entries.elementAt(index);
                 return AppBanner(
                   appFinding: appFinding,
-                  showSnap: widget.showSnap,
-                  showPackageKit: widget.showPackageKit,
+                  showPackageKit: true,
+                  showSnap: true,
+                  preferSnap: widget.preferSnap,
                 );
               },
             ),


### PR DESCRIPTION
Rather than performing a search with a scope limited by the selected package type, always search for all package types and filter the results afterwards. This way searching for only deb packages, will still include the snap versions in the results, if available and vice-versa.

Fix #1174, #1175