### PR TITLE
fix(explore): prefer desktop appstream components

### DIFF
--- a/lib/app/explore/explore_model.dart
+++ b/lib/app/explore/explore_model.dart
@@ -167,6 +167,11 @@ class ExploreModel extends SafeChangeNotifier {
   Future<AppstreamComponent?> _getAppstreamComponentFromSnap(Snap snap) =>
       _findAppstreamComponents(snap.name).then(
         (components) =>
+            components.firstWhereOrNull(
+              (e) =>
+                  e.package == snap.name &&
+                  e.type == AppstreamComponentType.desktopApplication,
+            ) ??
             components.firstWhereOrNull((e) => e.package == snap.name),
       );
 


### PR DESCRIPTION
If multiple appstream components belong to the same package, prefer the one that has type 'desktop-application' in
`_getAppstreamComponentFromSnap`.

[Screencast from 2023-05-25 14-53-12.webm](https://github.com/ubuntu-flutter-community/software/assets/113362648/a993c74e-c084-48c8-9573-b96e1da02752)


Fix #1210 