### PR TITLE
fix: Installed snap list taking long to load

### DIFF
--- a/lib/app/collection/snap_collection.dart
+++ b/lib/app/collection/snap_collection.dart
@@ -115,7 +115,7 @@ class SnapCollection extends StatelessWidget {
                                 : (i == installedSnaps.length - 1
                                     ? CollectionTilePosition.bottom
                                     : CollectionTilePosition.middle)),
-                        enabled: checkingForSnapUpdates == false,
+                        enabled: true,
                         onTap: () => SnapPage.push(
                           context: context,
                           snap: snap,
@@ -125,7 +125,7 @@ class SnapCollection extends StatelessWidget {
                           context: context,
                           snap: snap,
                           hasUpdate: false,
-                          enabled: checkingForSnapUpdates == false,
+                          enabled: true,
                         ),
                       ),
                       if ((i == 0 && installedSnaps.length > 1) ||

--- a/lib/services/snap_service.dart
+++ b/lib/services/snap_service.dart
@@ -128,9 +128,8 @@ class SnapService {
     }
   }
 
-  List<Snap> _localSnaps = [];
-  UnmodifiableListView<Snap> get localSnaps =>
-      UnmodifiableListView(_localSnaps);
+  List<Snap>? _localSnaps;
+  List<Snap>? get localSnaps => _localSnaps;
   Future<void> loadLocalSnaps() async {
     _localSnaps = (await _snapDClient.getSnaps());
   }


### PR DESCRIPTION
- let the installed snaps load as fast as possible in the UI then load the updates after
- forward the list from the service to the model, what was the reason for this unmodifyable list here @d-loose ? No critique, just curious
- make the list nullable, which gives one more state and does not leave the user with the "no snaps installed" message for some seconds while the list is loading
- to not disable the not-updates-rows while checking for updates, I see no reason why

Fixes #1219

[Bildschirmaufzeichnung vom 2023-05-30, 20-11-47.webm](https://github.com/ubuntu-flutter-community/software/assets/15329494/0701b6d6-990b-40c8-a489-779525cd2165)
