### PR TITLE
Use cached_netowork_image for app banners and icons

### DIFF
--- a/lib/app/common/app_banner.dart
+++ b/lib/app/common/app_banner.dart
@@ -15,6 +15,7 @@
  *
  */
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:provider/provider.dart';
@@ -26,7 +27,6 @@ import 'package:software/app/common/app_rating.dart';
 import 'package:software/app/common/constants.dart';
 import 'package:software/app/common/packagekit/package_page.dart';
 import 'package:software/app/common/rating_model.dart';
-import 'package:software/app/common/safe_network_image.dart';
 import 'package:software/app/common/snap/snap_page.dart';
 import 'package:software/l10n/l10n.dart';
 import 'package:software/services/appstream/appstream_utils.dart'
@@ -157,10 +157,11 @@ class AppImageBanner extends StatelessWidget {
                 topLeft: Radius.circular(10),
                 topRight: Radius.circular(10),
               ),
-              child: SafeNetworkImage(
-                fallBackIcon: fallBackLoadingIcon,
-                url: snap.bannerUrl,
+              child: CachedNetworkImage(
+                imageUrl: snap.bannerUrl!,
                 fit: BoxFit.cover,
+                placeholder: (context, url) => fallBackLoadingIcon,
+                errorWidget: (context, url, error) => fallBackLoadingIcon,
               ),
             ),
           ),

--- a/lib/app/common/app_icon.dart
+++ b/lib/app/common/app_icon.dart
@@ -15,6 +15,7 @@
  *
  */
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:software/app/common/constants.dart';
@@ -54,19 +55,15 @@ class AppIcon extends StatelessWidget {
           : SizedBox(
               height: size,
               width: size,
-              child: Image.network(
-                iconUrl!,
-                filterQuality: FilterQuality.medium,
-                fit: BoxFit.fitHeight,
-                frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-                  return frame == null
-                      ? fallBackLoadingIcon
-                      : AnimatedContainer(
-                          duration: const Duration(milliseconds: 500),
-                          child: child,
-                        );
-                },
-                errorBuilder: (context, error, stackTrace) => fallBackIcon,
+              child: CachedNetworkImage(
+                imageUrl: iconUrl!,
+                imageBuilder: (context, imageProvider) => Image(
+                  image: imageProvider,
+                  filterQuality: FilterQuality.medium,
+                  fit: BoxFit.fitHeight,
+                ),
+                placeholder: (context, url) => fallBackLoadingIcon,
+                errorWidget: (context, url, error) => fallBackIcon,
               ),
             ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   appstream: ^0.2.8
   async: ^2.10.0
   badges: ^2.0.3
+  cached_network_image: ^3.2.3
   collection: ^1.16.0
   connectivity_plus: ^2.3.1
   crypto: ^3.0.2


### PR DESCRIPTION
[`cached_network_image`](https://pub.dev/packages/cached_network_image) makes it possible to cache app icons and banners so that the images are not fetched from their url every time, making image loading faster.

Close #1116 