### PR TITLE
refactor(review): remove user name field

### DIFF
--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -51,10 +51,8 @@ class AppPage extends StatefulWidget {
     this.onReviewSend,
     this.onReviewChanged,
     this.onReviewTitleChanged,
-    this.onReviewUserChanged,
     this.review,
     this.reviewTitle,
-    this.reviewUser,
     this.reviewRating,
     this.onVote,
     this.onFlag,
@@ -74,12 +72,10 @@ class AppPage extends StatefulWidget {
   final double? reviewRating;
   final String? review;
   final String? reviewTitle;
-  final String? reviewUser;
   final void Function(double)? onRatingUpdate;
   final void Function()? onReviewSend;
   final void Function(String)? onReviewChanged;
   final void Function(String)? onReviewTitleChanged;
-  final void Function(String)? onReviewUserChanged;
   final Function(AppReview, bool)? onVote;
   final Function(AppReview)? onFlag;
 
@@ -157,7 +153,6 @@ class _AppPageState extends State<AppPage> {
       reviewRating: widget.reviewRating,
       review: widget.review,
       reviewTitle: widget.reviewTitle,
-      reviewUser: widget.reviewUser,
       appRating: widget.appData.appRating,
       userReviews: widget.appData.userReviews,
       appIsInstalled: widget.appIsInstalled,
@@ -165,7 +160,6 @@ class _AppPageState extends State<AppPage> {
       onReviewSend: widget.onReviewSend,
       onReviewChanged: widget.onReviewChanged,
       onReviewTitleChanged: widget.onReviewTitleChanged,
-      onReviewUserChanged: widget.onReviewUserChanged,
       onVote: widget.onVote,
       onFlag: widget.onFlag,
     );

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -31,9 +31,7 @@ class AppReviews extends StatefulWidget {
     this.review,
     this.onReviewChanged,
     this.onReviewTitleChanged,
-    this.onReviewUserChanged,
     this.reviewTitle,
-    this.reviewUser,
     this.reviewRating,
     this.onVote,
     this.onFlag,
@@ -44,13 +42,11 @@ class AppReviews extends StatefulWidget {
   final double? reviewRating;
   final String? reviewTitle;
   final String? review;
-  final String? reviewUser;
   final List<AppReview>? userReviews;
   final void Function(double)? onRatingUpdate;
   final void Function()? onReviewSend;
   final void Function(String)? onReviewChanged;
   final void Function(String)? onReviewTitleChanged;
-  final void Function(String)? onReviewUserChanged;
   final Function(AppReview, bool)? onVote;
   final Function(AppReview)? onFlag;
 
@@ -108,12 +104,10 @@ class _AppReviewsState extends State<AppReviews> {
                 reviewRating: widget.reviewRating,
                 review: widget.review,
                 reviewTitle: widget.reviewTitle,
-                reviewUser: widget.reviewUser,
                 onRatingUpdate: widget.onRatingUpdate,
                 onReviewSend: widget.onReviewSend,
                 onReviewChanged: widget.onReviewChanged,
                 onReviewTitleChanged: widget.onReviewTitleChanged,
-                onReviewUserChanged: widget.onReviewUserChanged,
               ),
             if (widget.appIsInstalled)
               const Padding(
@@ -192,10 +186,8 @@ class _ReviewPanel extends StatelessWidget {
     this.onReviewSend,
     this.onReviewChanged,
     this.onReviewTitleChanged,
-    this.onReviewUserChanged,
     this.review,
     this.reviewTitle,
-    this.reviewUser,
     this.reviewRating,
     this.appIsInstalled = false,
   });
@@ -204,14 +196,12 @@ class _ReviewPanel extends StatelessWidget {
   final double? reviewRating;
   final String? review;
   final String? reviewTitle;
-  final String? reviewUser;
   final bool appIsInstalled;
 
   final void Function(double)? onRatingUpdate;
   final void Function()? onReviewSend;
   final void Function(String)? onReviewChanged;
   final void Function(String)? onReviewTitleChanged;
-  final void Function(String)? onReviewUserChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -264,7 +254,6 @@ class _ReviewPanel extends StatelessWidget {
                   reviewRating: reviewRating,
                   review: review,
                   reviewTitle: reviewTitle,
-                  reviewUser: reviewUser,
                   onRatingUpdate: (rating) {
                     if (onRatingUpdate != null) {
                       onRatingUpdate!(rating);
@@ -273,7 +262,6 @@ class _ReviewPanel extends StatelessWidget {
                   onReviewSend: onReviewSend,
                   onReviewChanged: onReviewChanged,
                   onReviewTitleChanged: onReviewTitleChanged,
-                  onReviewUserChanged: onReviewUserChanged,
                 ),
               ),
               child: Text(context.l10n.yourReview),
@@ -294,22 +282,18 @@ class _MyReviewDialog extends StatefulWidget {
     this.onReviewSend,
     this.onReviewChanged,
     this.onReviewTitleChanged,
-    this.onReviewUserChanged,
     this.review,
     this.reviewTitle,
-    this.reviewUser,
   });
 
   final double? reviewRating;
   final String? review;
   final String? reviewTitle;
-  final String? reviewUser;
 
   final void Function(double)? onRatingUpdate;
   final void Function()? onReviewSend;
   final void Function(String)? onReviewChanged;
   final void Function(String)? onReviewTitleChanged;
-  final void Function(String)? onReviewUserChanged;
 
   @override
   State<_MyReviewDialog> createState() => _MyReviewDialogState();
@@ -317,9 +301,7 @@ class _MyReviewDialog extends StatefulWidget {
 
 class _MyReviewDialogState extends State<_MyReviewDialog> {
   late double? _reviewRating;
-  late TextEditingController _reviewController,
-      _reviewTitleController,
-      _reviewUserController;
+  late TextEditingController _reviewController, _reviewTitleController;
 
   @override
   void initState() {
@@ -327,14 +309,12 @@ class _MyReviewDialogState extends State<_MyReviewDialog> {
     _reviewRating = widget.reviewRating;
     _reviewController = TextEditingController(text: widget.review);
     _reviewTitleController = TextEditingController(text: widget.reviewTitle);
-    _reviewUserController = TextEditingController(text: widget.reviewUser);
   }
 
   bool get _isReviewValid =>
       _reviewRating != null &&
       _reviewController.text.length >= _kMinReviewLength &&
-      _reviewTitleController.text.length >= _kMinTitleLength &&
-      _reviewUserController.text.isNotEmpty;
+      _reviewTitleController.text.length >= _kMinTitleLength;
 
   @override
   Widget build(BuildContext context) {
@@ -373,20 +353,6 @@ class _MyReviewDialogState extends State<_MyReviewDialog> {
                 },
               ),
             ],
-          ),
-          const SizedBox(
-            height: kYaruPagePadding,
-          ),
-          TextField(
-            controller: _reviewUserController,
-            onChanged: widget.onReviewUserChanged,
-            style: theme.textTheme.bodyMedium,
-            decoration: InputDecoration(
-              label: Text(
-                context.l10n.yourReviewName,
-                style: theme.textTheme.bodyMedium,
-              ),
-            ),
           ),
           const SizedBox(
             height: kYaruPagePadding,
@@ -451,7 +417,6 @@ class _MyReviewDialogState extends State<_MyReviewDialog> {
                   animation: Listenable.merge([
                     _reviewController,
                     _reviewTitleController,
-                    _reviewUserController,
                   ]),
                   builder: (context, child) {
                     return ElevatedButton(

--- a/lib/app/common/packagekit/package_page.dart
+++ b/lib/app/common/packagekit/package_page.dart
@@ -289,12 +289,10 @@ class _PackagePageState extends State<PackagePage> {
       onReviewSend: () => review.submit(_ratingId, _ratingVersion),
       onRatingUpdate: (v) => review.rating = v,
       onReviewTitleChanged: (v) => review.title = v,
-      onReviewUserChanged: (v) => review.user = v,
       onReviewChanged: (v) => review.review = v,
       reviewRating: review.rating,
       review: review.review,
       reviewTitle: review.title,
-      reviewUser: review.user,
     );
   }
 }

--- a/lib/app/common/review_model.dart
+++ b/lib/app/common/review_model.dart
@@ -43,14 +43,6 @@ class ReviewModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  String? _user;
-  String? get user => _user;
-  set user(String? value) {
-    if (value == null || value == _user) return;
-    _user = value;
-    notifyListeners();
-  }
-
   Future<void> submit(String appId, String version) async {}
 
   Future<void> vote(AppReview review, bool positive) async {}

--- a/lib/app/common/snap/snap_page.dart
+++ b/lib/app/common/snap/snap_page.dart
@@ -253,12 +253,10 @@ class _SnapPageState extends State<SnapPage> {
       onReviewSend: () => review.submit(_ratingId, _ratingVersion),
       onRatingUpdate: (v) => review.rating = v,
       onReviewTitleChanged: (v) => review.title = v,
-      onReviewUserChanged: (v) => review.user = v,
       onReviewChanged: (v) => review.review = v,
       reviewRating: review.rating,
       review: review.review,
       reviewTitle: review.title,
-      reviewUser: review.user,
       onVote: review.vote,
       onFlag: review.flag,
     );


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Screenshot from 2023-06-08 17-07-30](https://github.com/ubuntu-flutter-community/software/assets/140617/d4f46230-0216-4f34-beb3-d9038ac4f3b5) | ![Screenshot from 2023-06-08 17-11-58](https://github.com/ubuntu-flutter-community/software/assets/140617/891bb419-df7a-4e83-960b-54485079e338) |

The glib library offers a way to get the user's [real name](https://docs.gtk.org/glib/func.get_real_name.html) and we have that available in [glib.dart](https://pub.dev/documentation/glib/latest/glib/GUtilsMixin/getRealName.html). It will be used in the service when submitting reviews, similarly to what gnome-software does.

See also:
- #1186