### PR TITLE
refactor(review): remove interactive rating bar

### DIFF
--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -92,15 +92,21 @@ class _AppReviewsState extends State<AppReviews> {
                 appRating: widget.appRating!,
               ),
             const Padding(
-              padding: EdgeInsets.only(top: 30, bottom: 30),
+              padding: EdgeInsets.only(top: 30, bottom: 20),
               child: Divider(
                 height: 0,
               ),
             ),
-            if (widget.appIsInstalled)
+            if (widget.review != null)
+              _Review(
+                userReview: AppReview(
+                  rating: widget.appRating?.average,
+                  review: widget.review,
+                  title: widget.reviewTitle,
+                ),
+              )
+            else if (widget.appIsInstalled)
               _ReviewPanel(
-                appIsInstalled: widget.appIsInstalled,
-                averageRating: widget.appRating?.average,
                 reviewRating: widget.reviewRating,
                 review: widget.review,
                 reviewTitle: widget.reviewTitle,
@@ -108,13 +114,6 @@ class _AppReviewsState extends State<AppReviews> {
                 onReviewSend: widget.onReviewSend,
                 onReviewChanged: widget.onReviewChanged,
                 onReviewTitleChanged: widget.onReviewTitleChanged,
-              ),
-            if (widget.appIsInstalled)
-              const Padding(
-                padding: EdgeInsets.only(top: 30, bottom: 30),
-                child: Divider(
-                  height: 0,
-                ),
               ),
             _ReviewsTrailer(
               userReviews: widget.userReviews,
@@ -181,7 +180,6 @@ class _ReviewPanel extends StatelessWidget {
   const _ReviewPanel({
     // ignore: unused_element
     super.key,
-    this.averageRating,
     this.onRatingUpdate,
     this.onReviewSend,
     this.onReviewChanged,
@@ -189,14 +187,11 @@ class _ReviewPanel extends StatelessWidget {
     this.review,
     this.reviewTitle,
     this.reviewRating,
-    this.appIsInstalled = false,
   });
 
-  final double? averageRating;
   final double? reviewRating;
   final String? review;
   final String? reviewTitle;
-  final bool appIsInstalled;
 
   final void Function(double)? onRatingUpdate;
   final void Function()? onReviewSend;
@@ -205,68 +200,33 @@ class _ReviewPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Text(
-                  '${context.l10n.rate}:',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-                const SizedBox(
-                  width: 10,
-                ),
-                RatingBar.builder(
-                  initialRating: reviewRating ?? 0,
-                  minRating: 1,
-                  direction: Axis.horizontal,
-                  itemCount: 5,
-                  itemPadding: const EdgeInsets.only(right: 5),
-                  itemSize: 40,
-                  itemBuilder: (context, _) => const MouseRegion(
-                    cursor: SystemMouseCursors.click,
-                    child: Icon(
-                      YaruIcons.star_filled,
-                      color: kStarColor,
-                      size: 2,
-                    ),
-                  ),
-                  unratedColor: theme.colorScheme.onSurface.withOpacity(0.2),
-                  onRatingUpdate: (rating) {
-                    if (onRatingUpdate != null) {
-                      onRatingUpdate!(rating);
-                    }
-                  },
-                  ignoreGestures: !appIsInstalled,
-                ),
-              ],
+        ElevatedButton(
+          onPressed: () => showDialog(
+            context: context,
+            builder: (context) => _MyReviewDialog(
+              reviewRating: reviewRating,
+              review: review,
+              reviewTitle: reviewTitle,
+              onRatingUpdate: (rating) {
+                if (onRatingUpdate != null) {
+                  onRatingUpdate!(rating);
+                }
+              },
+              onReviewSend: onReviewSend,
+              onReviewChanged: onReviewChanged,
+              onReviewTitleChanged: onReviewTitleChanged,
             ),
-            ElevatedButton(
-              onPressed: () => showDialog(
-                context: context,
-                builder: (context) => _MyReviewDialog(
-                  reviewRating: reviewRating,
-                  review: review,
-                  reviewTitle: reviewTitle,
-                  onRatingUpdate: (rating) {
-                    if (onRatingUpdate != null) {
-                      onRatingUpdate!(rating);
-                    }
-                  },
-                  onReviewSend: onReviewSend,
-                  onReviewChanged: onReviewChanged,
-                  onReviewTitleChanged: onReviewTitleChanged,
-                ),
-              ),
-              child: Text(context.l10n.yourReview),
-            )
-          ],
+          ),
+          child: Text(context.l10n.yourReview),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(top: 20, bottom: 20),
+          child: Divider(
+            height: 0,
+          ),
         ),
       ],
     );
@@ -482,8 +442,8 @@ class _ReviewsTrailer extends StatelessWidget {
 class _Review extends StatelessWidget {
   const _Review({
     required this.userReview,
-    required this.onFlag,
-    required this.onVote,
+    this.onFlag,
+    this.onVote,
   });
 
   final AppReview userReview;
@@ -561,14 +521,15 @@ class _Review extends StatelessWidget {
             ),
           ],
         ),
-        const SizedBox(
-          height: kYaruPagePadding,
-        ),
-        _ReviewRatingBar(
-          userReview: userReview,
-          onFlag: onFlag,
-          onVote: onVote,
-        ),
+        if (onFlag != null || onVote != null)
+          Padding(
+            padding: const EdgeInsets.only(top: kYaruPagePadding),
+            child: _ReviewRatingBar(
+              userReview: userReview,
+              onFlag: onFlag,
+              onVote: onVote,
+            ),
+          ),
         const Padding(
           padding: EdgeInsets.only(top: 20, bottom: 20),
           child: Divider(


### PR DESCRIPTION
There was an interactive rating bar outside the review dialog. This is not possible with ODRS because a rating can only be [submitted](https://github.com/GNOME/odrs-web/blob/51cc0b55cba833ca0f37209f339ea31f87906e72/odrs/views_api.py#L93) as part of a review. Also, re-submitting a review to ODRS is not possible (throws an "already reviewed" error).

## Before

![image](https://github.com/ubuntu-flutter-community/software/assets/140617/3ba1be11-076a-4c39-bb86-894299dd556e)

## After

### Already reviewed

If the user already has submitted a review, it is shown _without_ voting or reporting buttons and regardless of whether the app is currently installed.

![image](https://github.com/ubuntu-flutter-community/software/assets/140617/211984c1-c11c-4b91-8ece-193b79abb331)

### Installed, not reviewed

The review button is shown only if the app is installed but not reviewed.

![image](https://github.com/ubuntu-flutter-community/software/assets/140617/7e662e36-6269-41a9-83a1-6b4e95a10f1c)

### Not installed nor reviewed

When the app is neither installed nor reviewed, neither above is shown.

![Screenshot from 2023-06-09 09-30-12](https://github.com/ubuntu-flutter-community/software/assets/140617/e162bd25-db7c-489e-9cb9-d7548c129c9d)

Close: #1251