### PR TITLE
reviews: filter dropdown missing from the 'show all reviews' dropdown

### DIFF
--- a/lib/app/common/app_page/app_page.dart
+++ b/lib/app/common/app_page/app_page.dart
@@ -33,10 +33,11 @@ import 'package:software/app/common/link.dart';
 import 'package:software/app/common/safe_network_image.dart';
 import 'package:software/app/explore/explore_model.dart';
 import 'package:software/l10n/l10n.dart';
+import 'package:yaru_colors/yaru_colors.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
 import '../expandable_title.dart';
-import 'package:yaru_colors/yaru_colors.dart';
 
 class AppPage extends StatefulWidget {
   const AppPage({

--- a/lib/app/common/app_page/review_sort_by.dart
+++ b/lib/app/common/app_page/review_sort_by.dart
@@ -1,0 +1,17 @@
+import 'package:software/l10n/l10n.dart';
+
+enum ReviewSortBy {
+  mostRecent,
+  mostUseful,
+  highestRating,
+  lowestRating;
+
+  String localize(AppLocalizations l10n) {
+    return switch (this) {
+      mostRecent => l10n.appReviewsMostRecent,
+      mostUseful => l10n.appReviewsMostUseful,
+      highestRating => l10n.appReviewsHighestRating,
+      lowestRating => l10n.appReviewsLowestRating,
+    };
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -240,5 +240,9 @@
   "report": "Report",
   "reportAbuse": "Report abuse",
   "reportReviewDialogTitle": "Report review",
-  "reportReviewDialogBody": "You can report a review for abusive, rude, or discriminatory behavior. Once reported, a review will be hidden until it has been checked by an administrator."
+  "reportReviewDialogBody": "You can report a review for abusive, rude, or discriminatory behavior. Once reported, a review will be hidden until it has been checked by an administrator.",
+  "appReviewsMostRecent": "Most recent",
+  "appReviewsMostUseful": "Most useful",
+  "appReviewsHighestRating": "Highest Rating",
+  "appReviewsLowestRating": "Lowest Rating"
 }


### PR DESCRIPTION
@jpnurmi to keep the app page and its children independent of any models I've moved the state just to the dialog itself. In this case this should be okay since the sorting is not something to persist (yet?).

If the other designers want the sorting to be also inside the main page, I could create a separate state for this there

[Bildschirmaufzeichnung vom 2023-06-16, 13-58-42.webm](https://github.com/ubuntu-flutter-community/software/assets/15329494/e5a75b9f-f220-4755-9521-86974e593992)

Fixes #1177